### PR TITLE
Use registered API route in set_flow_run_state just in case

### DIFF
--- a/src/prefect_server/api/states.py
+++ b/src/prefect_server/api/states.py
@@ -97,7 +97,7 @@ async def set_flow_run_state(
         # we might want to batch this rather than kicking off lots of asyncio
         # tasks at once.
         await asyncio.gather(
-            *(set_task_run_state(t.id, state) for t in to_cancel),
+            *(api.states.set_task_run_state(t.id, state) for t in to_cancel),
             return_exceptions=True,
         )
 


### PR DESCRIPTION
I'm not sure this is important, but just in case it is.

Ultimately I'm realizing that the real burden of calling the right routes falls to the server codebase.