### PR TITLE
disable sens-o-matic by default, allow specifying endpoint via config

### DIFF
--- a/changes/pr11.yml
+++ b/changes/pr11.yml
@@ -1,0 +1,6 @@
+enhancement:
+    - "Make sens-o-matic configurable - [#11](https://github.com/PrefectHQ/server/pull/11)"
+  
+  contributor:
+    - "[Alex Cano](https://github.com/alexisprince1994)"
+  

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -61,6 +61,10 @@ level = "DEBUG"
 # The log format
 format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
 
+[sens_o_matic]
+enabled = false
+url = ""
+
 
 [sendgrid]
 

--- a/src/prefect_server/utilities/sens_o_matic_events.py
+++ b/src/prefect_server/utilities/sens_o_matic_events.py
@@ -20,6 +20,9 @@ async def emit_delete_event(row_id: str, table_name: str) -> dict:
     if env == "local":
         return None
 
+    if not config.sens_o_matic.enabled:
+        return None
+
     try:
         event_id = str(uuid.uuid4())
         payload = {"cloud_environment": env, "row_id": row_id, "table_name": table_name}
@@ -30,14 +33,15 @@ async def emit_delete_event(row_id: str, table_name: str) -> dict:
             "payload": payload,
         }
         result = await sens_o_matic_httpx_client.post(
-            "https://sens-o-matic.prefect.io/",
+            config.sens_o_matic.url,
             json=event,
             headers={"X-PREFECT-EVENT": "prefect_server-0.0.1"},
             timeout=10,
         )
         logger.debug("Delete event sent to sens-o-matic: %s", str(result))
     except Exception as e:
-        # Log the information that we were trying to send to sens-o-matic so Dylan can backfill
+        # Log the information that we were trying to send to sens-o-matic
+        # so the delete event is captured somewhere
         logger.error(
             "Error during attempt to send event to sens-o-matic: %s", str(event)
         )


### PR DESCRIPTION
**Thanks for contributing to the Prefect Server!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] add a changelog entry in the `changes/` directory (if appropriate)

Note that your PR will not be reviewed unless these two boxes are checked.

As far as I can tell, the bunches of service tests that are failing were failing on the master branch as well.

## What does this PR change?
This PR allows the configuration of the `sens-o-matic` external integration. This disables the external facing calls by default, and when enabled, requires users to specify their own `url` that will receive the payloads.


## Why is this PR important?
This PR will ensure that not all delete events from every users server installation will bombard Prefect's internal sens-o-matic tool, and also allows users to specify their own.

