### PR TITLE
Remove unused state_id foreign key

### DIFF
--- a/changes/EXAMPLE.yaml
+++ b/changes/EXAMPLE.yaml
@@ -6,6 +6,7 @@
 #   - fix
 #   - deprecation
 #   - breaking (for breaking changes)
+#   - migration (for database migrations)
 #
 # 2. Fill in one (or more) bullet points under the heading, describing the change.
 #    Markdown syntax may be used.

--- a/changes/pr35.yaml
+++ b/changes/pr35.yaml
@@ -15,5 +15,5 @@
 #
 # Here's an example of a PR that adds an enhancement
 
-enhancement:
+migration:
   - "Remove unused `state_id` column - [#35](https://github.com/PrefectHQ/server/pull/35)"

--- a/changes/pr35.yaml
+++ b/changes/pr35.yaml
@@ -1,0 +1,19 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Remove unused `state_id` column - [#35](https://github.com/PrefectHQ/server/pull/35)"

--- a/services/hasura/migrations/versions/metadata-3398e4807bfb.yaml
+++ b/services/hasura/migrations/versions/metadata-3398e4807bfb.yaml
@@ -1,0 +1,150 @@
+version: 2
+tables:
+- table:
+    schema: public
+    name: cloud_hook
+- table:
+    schema: public
+    name: edge
+  object_relationships:
+  - name: downstream_task
+    using:
+      foreign_key_constraint_on: downstream_task_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+- table:
+    schema: public
+    name: flow
+  object_relationships:
+  - name: flow_group
+    using:
+      foreign_key_constraint_on: flow_group_id
+  - name: project
+    using:
+      foreign_key_constraint_on: project_id
+  array_relationships:
+  - name: edges
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          schema: public
+          name: edge
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          schema: public
+          name: flow_run
+  - name: tasks
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          schema: public
+          name: task
+- table:
+    schema: public
+    name: flow_group
+  array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: flow_group_id
+        table:
+          schema: public
+          name: flow
+- table:
+    schema: public
+    name: flow_run
+  object_relationships:
+  - name: current_state
+    using:
+      foreign_key_constraint_on: state_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  array_relationships:
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          schema: public
+          name: flow_run_state
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          schema: public
+          name: task_run
+- table:
+    schema: public
+    name: flow_run_state
+  object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+- table:
+    schema: public
+    name: log
+- table:
+    schema: public
+    name: project
+  array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          schema: public
+          name: flow
+- table:
+    schema: public
+    name: task
+  object_relationships:
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  array_relationships:
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          schema: public
+          name: task_run
+- table:
+    schema: public
+    name: task_run
+  object_relationships:
+  - name: current_state
+    using:
+      foreign_key_constraint_on: state_id
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  - name: task
+    using:
+      foreign_key_constraint_on: task_id
+  array_relationships:
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          schema: public
+          name: task_run_state
+- table:
+    schema: public
+    name: task_run_state
+  object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id

--- a/services/hasura/migrations/versions/metadata-b9086bd4b962.yaml
+++ b/services/hasura/migrations/versions/metadata-b9086bd4b962.yaml
@@ -148,6 +148,9 @@ tables:
           name: task_run
           schema: public
   object_relationships:
+  - name: current_state
+    using:
+      foreign_key_constraint_on: state_id
   - name: flow
     using:
       foreign_key_constraint_on: flow_id
@@ -173,6 +176,9 @@ tables:
           name: task_run_state
           schema: public
   object_relationships:
+  - name: current_state
+    using:
+      foreign_key_constraint_on: state_id
   - name: flow_run
     using:
       foreign_key_constraint_on: flow_run_id

--- a/services/postgres/alembic/env.py
+++ b/services/postgres/alembic/env.py
@@ -67,9 +67,7 @@ def apply_hasura_metadata(context):
 
     fn = context.get_context().opts.get("fn")
     if fn and fn.__name__ == "upgrade":
-        dest_rev = context.get_context().opts.get("destination_rev")
-        head = context.script.get_current_head()
-        if dest_rev == "heads" or script.revision == head:
+        if script.revision == context.script.get_current_head():
             hasura_revision = None
         else:
             hasura_revision = script.up_revision

--- a/services/postgres/alembic/env.py
+++ b/services/postgres/alembic/env.py
@@ -70,7 +70,7 @@ def apply_hasura_metadata(context):
         if script.revision == context.script.get_current_head():
             hasura_revision = None
         else:
-            hasura_revision = script.up_revision
+            hasura_revision = script.revision
     elif fn and fn.__name__ == "downgrade":
         hasura_revision = script.down_revision
     else:

--- a/services/postgres/alembic/env.py
+++ b/services/postgres/alembic/env.py
@@ -67,12 +67,14 @@ def apply_hasura_metadata(context):
 
     fn = context.get_context().opts.get("fn")
     if fn and fn.__name__ == "upgrade":
-        if context.get_context().opts.get("destination_rev") == "heads":
+        dest_rev = context.get_context().opts.get("destination_rev")
+        head = context.script.get_current_head()
+        if dest_rev == "heads" or script.revision == head:
             hasura_revision = None
         else:
-            hasura_revision = script.down_revision
+            hasura_revision = script.up_revision
     elif fn and fn.__name__ == "downgrade":
-        hasura_revision = script.revision
+        hasura_revision = script.down_revision
     else:
         return
 

--- a/services/postgres/alembic/env.py
+++ b/services/postgres/alembic/env.py
@@ -65,16 +65,10 @@ def apply_hasura_metadata(context):
     if not script:
         return
 
-    fn = context.get_context().opts.get("fn")
-    if fn and fn.__name__ == "upgrade":
-        if script.revision == context.script.get_current_head():
-            hasura_revision = None
-        else:
-            hasura_revision = script.revision
-    elif fn and fn.__name__ == "downgrade":
-        hasura_revision = script.down_revision
+    if script.revision == context.script.get_current_head():
+        hasura_revision = None
     else:
-        return
+        hasura_revision = script.revision
 
     # attempt to load the corresponding hasura metadata
     metadata_path = os.path.join(__file__, "../../../hasura/migrations")

--- a/services/postgres/alembic/versions/2020-08-08T205817_remove_state_id_foreign_keys.py
+++ b/services/postgres/alembic/versions/2020-08-08T205817_remove_state_id_foreign_keys.py
@@ -1,0 +1,256 @@
+"""
+Remove state_id foreign keys
+
+Revision ID: c1f317aa658c
+Revises: b9086bd4b962
+Create Date: 2020-08-08 20:58:17.784897
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "c1f317aa658c"
+down_revision = "b9086bd4b962"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        DROP FUNCTION update_flow_run_with_latest_state CASCADE;
+        DROP FUNCTION update_task_run_with_latest_state CASCADE;
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION update_flow_run_with_latest_state() RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+                    BEGIN
+                        UPDATE flow_run
+                        SET
+                            version = new_latest_state.version,
+                            -- below are fields that we only include for backwards-compatibility
+                            state=new_latest_state.state,
+                            serialized_state=new_latest_state.serialized_state,
+                            state_start_time=new_latest_state.start_time,
+                            state_timestamp=new_latest_state.timestamp,
+                            state_message=new_latest_state.message,
+                            state_result=new_latest_state.result
+                        FROM
+                            -- only select the latest row
+                            (
+                                SELECT DISTINCT ON (flow_run_id)
+                                    id,
+                                    version,
+                                    flow_run_id,
+                                    state,
+                                    serialized_state,
+                                    start_time,
+                                    timestamp,
+                                    message,
+                                    result
+                                FROM new_state
+                                ORDER BY flow_run_id, version DESC, timestamp DESC
+                            ) AS new_latest_state
+                        WHERE
+                            new_latest_state.flow_run_id = flow_run.id
+                            AND (
+                                flow_run.version IS NULL
+                                OR (
+                                    new_latest_state.version >= COALESCE(flow_run.version, -1)
+                                    AND new_latest_state.timestamp > COALESCE(flow_run.state_timestamp, '2000-01-01')));
+                        RETURN NEW;
+                    END;
+                    $$;
+
+
+        CREATE FUNCTION update_task_run_with_latest_state() RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+                    BEGIN
+                        UPDATE task_run
+                        SET
+                            version = new_latest_state.version,
+                            -- below are fields that we only include for backwards-compatibility
+                            state=new_latest_state.state,
+                            serialized_state=new_latest_state.serialized_state,
+                            state_start_time=new_latest_state.start_time,
+                            state_timestamp=new_latest_state.timestamp,
+                            state_message=new_latest_state.message,
+                            state_result=new_latest_state.result
+                        FROM
+                            -- only select the latest row
+                            (
+                                SELECT DISTINCT ON (task_run_id)
+                                    id,
+                                    version,
+                                    task_run_id,
+                                    state,
+                                    serialized_state,
+                                    start_time,
+                                    timestamp,
+                                    message,
+                                    result
+                                FROM new_state
+                                ORDER BY task_run_id, version DESC, timestamp DESC
+                            ) AS new_latest_state
+                        WHERE
+                            new_latest_state.task_run_id = task_run.id
+                            AND (
+                                task_run.version IS NULL
+                                OR (
+                                    new_latest_state.version >= COALESCE(task_run.version, -1)
+                                    AND new_latest_state.timestamp > COALESCE(task_run.state_timestamp, '2000-01-01')));
+                        RETURN NEW;
+                    END;
+                    $$;
+
+            CREATE TRIGGER update_flow_run_after_inserting_state
+            AFTER INSERT ON flow_run_state
+            REFERENCING NEW TABLE AS new_state
+            FOR EACH STATEMENT
+            EXECUTE PROCEDURE update_flow_run_with_latest_state();
+
+            CREATE TRIGGER update_task_run_after_inserting_state
+            AFTER INSERT ON task_run_state
+            REFERENCING NEW TABLE AS new_state
+            FOR EACH STATEMENT
+            EXECUTE PROCEDURE update_task_run_with_latest_state();
+            """
+    )
+
+    op.drop_column("flow_run", "state_id")
+    op.drop_column("task_run", "state_id")
+
+
+def downgrade():
+    op.add_column(
+        "flow_run",
+        sa.Column(
+            "state_id", UUID, sa.ForeignKey("flow_run_state.id", ondelete="SET NULL")
+        ),
+    )
+    op.add_column(
+        "task_run",
+        sa.Column(
+            "state_id", UUID, sa.ForeignKey("task_run_state.id", ondelete="SET NULL")
+        ),
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_flow_run__state_id ON flow_run USING btree (state_id);
+        CREATE INDEX ix_task_run__state_id ON task_run USING btree (state_id);
+        """
+    )
+
+    op.execute(
+        """
+        DROP FUNCTION update_flow_run_with_latest_state CASCADE;
+        DROP FUNCTION update_task_run_with_latest_state CASCADE;
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION update_flow_run_with_latest_state() RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+                    BEGIN
+                        UPDATE flow_run
+                        SET
+                            version = new_latest_state.version,
+                            state_id = new_latest_state.id,
+                            -- below are fields that we only include for backwards-compatibility
+                            state=new_latest_state.state,
+                            serialized_state=new_latest_state.serialized_state,
+                            state_start_time=new_latest_state.start_time,
+                            state_timestamp=new_latest_state.timestamp,
+                            state_message=new_latest_state.message,
+                            state_result=new_latest_state.result
+                        FROM
+                            -- only select the latest row
+                            (
+                                SELECT DISTINCT ON (flow_run_id)
+                                    id,
+                                    version,
+                                    flow_run_id,
+                                    state,
+                                    serialized_state,
+                                    start_time,
+                                    timestamp,
+                                    message,
+                                    result
+                                FROM new_state
+                                ORDER BY flow_run_id, version DESC, timestamp DESC
+                            ) AS new_latest_state
+                        WHERE
+                            new_latest_state.flow_run_id = flow_run.id
+                            AND (
+                                flow_run.version IS NULL
+                                OR (
+                                    new_latest_state.version >= COALESCE(flow_run.version, -1)
+                                    AND new_latest_state.timestamp > COALESCE(flow_run.state_timestamp, '2000-01-01')));
+                        RETURN NEW;
+                    END;
+                    $$;
+
+
+        CREATE FUNCTION update_task_run_with_latest_state() RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+                    BEGIN
+                        UPDATE task_run
+                        SET
+                            version = new_latest_state.version,
+                            state_id = new_latest_state.id,
+                            -- below are fields that we only include for backwards-compatibility
+                            state=new_latest_state.state,
+                            serialized_state=new_latest_state.serialized_state,
+                            state_start_time=new_latest_state.start_time,
+                            state_timestamp=new_latest_state.timestamp,
+                            state_message=new_latest_state.message,
+                            state_result=new_latest_state.result
+                        FROM
+                            -- only select the latest row
+                            (
+                                SELECT DISTINCT ON (task_run_id)
+                                    id,
+                                    version,
+                                    task_run_id,
+                                    state,
+                                    serialized_state,
+                                    start_time,
+                                    timestamp,
+                                    message,
+                                    result
+                                FROM new_state
+                                ORDER BY task_run_id, version DESC, timestamp DESC
+                            ) AS new_latest_state
+                        WHERE
+                            new_latest_state.task_run_id = task_run.id
+                            AND (
+                                task_run.version IS NULL
+                                OR (
+                                    new_latest_state.version >= COALESCE(task_run.version, -1)
+                                    AND new_latest_state.timestamp > COALESCE(task_run.state_timestamp, '2000-01-01')));
+                        RETURN NEW;
+                    END;
+                    $$;
+
+            CREATE TRIGGER update_flow_run_after_inserting_state
+            AFTER INSERT ON flow_run_state
+            REFERENCING NEW TABLE AS new_state
+            FOR EACH STATEMENT
+            EXECUTE PROCEDURE update_flow_run_with_latest_state();
+
+            CREATE TRIGGER update_task_run_after_inserting_state
+            AFTER INSERT ON task_run_state
+            REFERENCING NEW TABLE AS new_state
+            FOR EACH STATEMENT
+            EXECUTE PROCEDURE update_task_run_with_latest_state();
+            """
+    )

--- a/src/prefect_server/database/_models.py
+++ b/src/prefect_server/database/_models.py
@@ -135,7 +135,6 @@ class FlowRun(HasuraModel):
     auto_scheduled: bool = None
     name: str = None
     times_resurrected: int = None
-    state_id: str = None
     idempotency_key: str = None
 
     # state fields
@@ -149,7 +148,6 @@ class FlowRun(HasuraModel):
     # relationships
     tenant: Tenant = None
     flow: Flow = None
-    current_state: "FlowRunState" = None
     states: List["FlowRunState"] = None
     task_runs: List["TaskRun"] = None
     logs: List["Log"] = None
@@ -173,7 +171,6 @@ class TaskRun(HasuraModel):
     duration: datetime.timedelta = None
     run_count: int = None
     cache_key: str = None
-    state_id: str = None
 
     # state fields
     state: str = None
@@ -188,7 +185,6 @@ class TaskRun(HasuraModel):
     task: Task = None
     states: List["TaskRunState"] = None
     logs: List["Log"] = None
-    current_state: "TaskRunState" = None
 
 
 @plugins.register_model("FlowRunState")

--- a/tests/api/test_cloud_hooks.py
+++ b/tests/api/test_cloud_hooks.py
@@ -27,14 +27,20 @@ async def state_event(flow_run_id):
             "version": True,
             "flow": {"id", "name", "version_group_id"},
             "tenant": {"id", "slug"},
-            "current_state": {"state", "serialized_state", "version"},
+            "state": True,
+            "serialized_state": True,
+            "version": True,
         }
     )
 
     return events.FlowRunStateChange(
         flow_run=flow_run,
         tenant=flow_run.tenant,
-        state=flow_run.current_state,
+        state=dict(
+            state=flow_run.state,
+            serialized_state=flow_run.serialized_state,
+            version=flow_run.version,
+        ),
         flow=flow_run.flow,
     )
 

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -13,7 +13,7 @@ from prefect.engine.state import (
     Submitted,
     Success,
 )
-from prefect.utilities.graphql import EnumValue
+from prefect.utilities.graphql import EnumValue, with_args
 from prefect import api
 from prefect_server import config
 from prefect_server.database import models
@@ -532,10 +532,16 @@ class TestGetOrCreateMappedChildren:
         map_indices = []
         for child in mapped_children:
             task_run = await models.TaskRun.where(id=child).first(
-                {"state_id", "map_index"}
+                {
+                    "map_index": True,
+                    with_args(
+                        "states",
+                        {"order_by": {"version": EnumValue("desc")}, "limit": 1},
+                    ): {"id"},
+                }
             )
             map_indices.append(task_run.map_index)
-            assert task_run.state_id is not None
+            assert task_run.states[0] is not None
         assert map_indices == sorted(map_indices)
 
     async def test_get_or_create_mapped_children_retrieves_children(
@@ -636,10 +642,16 @@ class TestGetOrCreateMappedChildren:
         # confirm each of the mapped children has a state and is ordered properly
         for child in mapped_children:
             task_run = await models.TaskRun.where(id=child).first(
-                {"state_id", "map_index"}
+                {
+                    "map_index": True,
+                    with_args(
+                        "states",
+                        {"order_by": {"version": EnumValue("desc")}, "limit": 1},
+                    ): {"id"},
+                }
             )
             map_indices.append(task_run.map_index)
-            assert task_run.state_id is not None
+            assert task_run.states[0] is not None
         assert map_indices == sorted(map_indices)
 
         # confirm the one child created with a state only has the one state

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -35,8 +35,7 @@ async def test_full_migration_downgrade_works_with_data_in_db(
         subprocess.check_output(["prefect-server", "database", "upgrade", "-y"])
 
 
-# @pytest.mark.parametrize("n", [1, 2, 3])
-@pytest.mark.parametrize("n", [3])
+@pytest.mark.parametrize("n", [1, 2, 3])
 async def test_recent_migration_upgrades_work_with_data_in_db(
     flow_id, task_run_id, task_run_id_2, task_run_id_3, n,
 ):
@@ -56,5 +55,6 @@ async def test_recent_migration_upgrades_work_with_data_in_db(
             )
 
     finally:
-        # upgrade DB so other tests can run
+        # upgrade DB so other tests can run in case this test errored and left it
+        # in a bad state
         subprocess.check_output(["prefect-server", "database", "upgrade", "-y"])

--- a/tests/database/test_state_triggers.py
+++ b/tests/database/test_state_triggers.py
@@ -16,7 +16,7 @@ class TestFlowRunStateTrigger:
 
         await models.FlowRun.where(id=flow_run_id).update({"version": original_version})
         old_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -33,11 +33,10 @@ class TestFlowRunStateTrigger:
         ).insert()
 
         new_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         assert new_run.version == 10
-        assert new_run.state_id != old_run.state_id
         assert new_run.heartbeat is None
 
     async def test_equal_version_only_updates_if_timestamp_is_greater_than_current(
@@ -93,7 +92,7 @@ class TestFlowRunStateTrigger:
 
         await models.FlowRun.where(id=flow_run_id).update({"version": 10})
         old_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -115,11 +114,10 @@ class TestFlowRunStateTrigger:
         )
 
         new_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "state_timestamp", "state_id"}
+            {"version", "state_timestamp"}
         )
 
         assert new_run.version == 100 != old_run.version
-        assert new_run.state_id != old_run.state_id
         assert new_run.state_timestamp == dt.add(seconds=100)
 
     @pytest.mark.parametrize("original_version", [11, 100])
@@ -130,7 +128,7 @@ class TestFlowRunStateTrigger:
         await models.FlowRun.where(id=flow_run_id).update({"version": original_version})
 
         old_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -147,11 +145,10 @@ class TestFlowRunStateTrigger:
         ).insert()
 
         new_run = await models.FlowRun.where(id=flow_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         assert new_run.version == old_run.version
-        assert new_run.state_id == old_run.state_id
         assert new_run.heartbeat is None
 
 
@@ -163,7 +160,7 @@ class TestTaskRunStateTrigger:
 
         await models.TaskRun.where(id=task_run_id).update({"version": original_version})
         old_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -180,11 +177,10 @@ class TestTaskRunStateTrigger:
         ).insert()
 
         new_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         assert new_run.version == 10
-        assert new_run.state_id != old_run.state_id
         assert new_run.heartbeat is None
 
     async def test_equal_version_only_updates_if_timestamp_is_greater_than_current(
@@ -240,7 +236,7 @@ class TestTaskRunStateTrigger:
 
         await models.TaskRun.where(id=task_run_id).update({"version": 10})
         old_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -262,11 +258,10 @@ class TestTaskRunStateTrigger:
         )
 
         new_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "state_timestamp", "state_id"}
+            {"version", "state_timestamp"}
         )
 
         assert new_run.version == 100 != old_run.version
-        assert new_run.state_id != old_run.state_id
         assert new_run.state_timestamp == dt.add(seconds=100)
 
     @pytest.mark.parametrize("original_version", [11, 100])
@@ -277,7 +272,7 @@ class TestTaskRunStateTrigger:
         await models.TaskRun.where(id=task_run_id).update({"version": original_version})
 
         old_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         dt = pendulum.now("UTC")
@@ -294,8 +289,7 @@ class TestTaskRunStateTrigger:
         ).insert()
 
         new_run = await models.TaskRun.where(id=task_run_id).first(
-            {"version", "heartbeat", "state_id"}
+            {"version", "heartbeat"}
         )
 
         assert new_run.version == old_run.version
-        assert new_run.state_id == old_run.state_id

--- a/update_changelog.py
+++ b/update_changelog.py
@@ -13,6 +13,7 @@ SECTIONS = [
     ("fix", "Fixes"),
     ("deprecation", "Deprecations"),
     ("breaking", "Breaking Changes"),
+    ("migration", "Database Migrations"),
     ("contributor", "Contributors"),
 ]
 DEDUPLICATE_SECTIONS = ["contributor"]


### PR DESCRIPTION
**Thanks for contributing to Prefect Server!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] adds a changelog entry to the `changes/` directory (if appropriate)

Note that your PR will not be reviewed unless these two boxes are checked.

## What does this PR change?
This PR removes a foreign key on `task_run.state_id` and `flow_run.state_id` that once pointed to the current state; it is unused and creates performance issues.


## Why is this PR important?


