### PR TITLE
Toggle set schedule active intelligently

### DIFF
--- a/changes/pr37.yaml
+++ b/changes/pr37.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Set schedule to inactive if neither Flow nor Flow Group have a schedule - [#37](https://github.com/PrefectHQ/server/pull/37)"


### PR DESCRIPTION
**Thanks for contributing to Prefect Server!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] adds a changelog entry to the `changes/` directory (if appropriate)

Note that your PR will not be reviewed unless these two boxes are checked.

## What does this PR change?
This PR sets a Flow's schedule to inactive if neither it nor its Flow Group have a schedule.  Not a bug, but the UI would display an active schedule with a warning message anytime I registered a Flow with no schedule and that was bothering me.


## Why is this PR important?
Better match expectations.  **cc:** @zhen0 