### PR TITLE
Dedupe labels passed through the labels resolver

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
-- None
+- Updates the label resolver to dedupe labels input - [#38](https://github.com/PrefectHQ/server/pull/38)
 
 ### Infrastructure
 
@@ -25,4 +25,3 @@
 ### Deprecations
 
 - None
-

--- a/src/prefect_server/graphql/flow_groups.py
+++ b/src/prefect_server/graphql/flow_groups.py
@@ -20,7 +20,7 @@ async def resolve_set_flow_group_default_parameters(
 async def resolve_set_flow_group_labels(
     obj: Any, info: GraphQLResolveInfo, input: dict
 ) -> dict:
-    labels = set(input["labels"]) if input["labels"] else set()
+    labels = set(input["labels"]) if input["labels"] else None
     result = await api.flow_groups.set_flow_group_labels(
         flow_group_id=input["flow_group_id"], labels=labels
     )

--- a/src/prefect_server/graphql/flow_groups.py
+++ b/src/prefect_server/graphql/flow_groups.py
@@ -20,8 +20,9 @@ async def resolve_set_flow_group_default_parameters(
 async def resolve_set_flow_group_labels(
     obj: Any, info: GraphQLResolveInfo, input: dict
 ) -> dict:
+    labels = set(input["labels"]) if input["labels"] else set()
     result = await api.flow_groups.set_flow_group_labels(
-        flow_group_id=input["flow_group_id"], labels=input["labels"]
+        flow_group_id=input["flow_group_id"], labels=labels
     )
     return {"success": result}
 

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -54,7 +54,7 @@ class TestSetFlowGroupLabels:
     async def test_set_flow_group_labels(self, flow_group_id):
         labels = ["meep", "morp"]
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels is None
+        assert not flow_group.labels
 
         success = await api.flow_groups.set_flow_group_labels(
             flow_group_id=flow_group_id, labels=labels

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -70,7 +70,7 @@ class TestSetFlowGroupLabels:
             set=dict(labels=["zaphod", "beeblebrox"])
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == ["zaphod", "beeblebrox"]
+        assert flow_group.labels == set(["zaphod", "beeblebrox"])
 
         await api.flow_groups.set_flow_group_labels(
             flow_group_id=flow_group_id, labels=labels

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -62,7 +62,7 @@ class TestSetFlowGroupLabels:
         assert success is True
 
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == labels
+        assert flow_group.labels == set(labels)
 
     async def test_set_flow_group_labels_overwrites_existing(self, flow_group_id):
         labels = ["meep", "morp"]
@@ -76,7 +76,7 @@ class TestSetFlowGroupLabels:
             flow_group_id=flow_group_id, labels=labels
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == labels
+        assert flow_group.labels == set(labels)
 
     async def test_set_flow_group_labels_for_invalid_flow_group(self):
         success = await api.flow_groups.set_flow_group_labels(

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -54,7 +54,7 @@ class TestSetFlowGroupLabels:
     async def test_set_flow_group_labels(self, flow_group_id):
         labels = ["meep", "morp"]
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert len(flow_group.labels) == 0
+        assert flow_group.labels is None
 
         success = await api.flow_groups.set_flow_group_labels(
             flow_group_id=flow_group_id, labels=labels

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -70,7 +70,7 @@ class TestSetFlowGroupLabels:
             set=dict(labels=["zaphod", "beeblebrox"])
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == set(["zaphod", "beeblebrox"])
+        assert set(flow_group.labels) == set(["zaphod", "beeblebrox"])
 
         await api.flow_groups.set_flow_group_labels(
             flow_group_id=flow_group_id, labels=labels

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -62,7 +62,7 @@ class TestSetFlowGroupLabels:
         assert success is True
 
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == set(labels)
+        assert set(flow_group.labels) == set(labels)
 
     async def test_set_flow_group_labels_overwrites_existing(self, flow_group_id):
         labels = ["meep", "morp"]
@@ -76,7 +76,7 @@ class TestSetFlowGroupLabels:
             flow_group_id=flow_group_id, labels=labels
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == set(labels)
+        assert set(flow_group.labels) == set(labels)
 
     async def test_set_flow_group_labels_for_invalid_flow_group(self):
         success = await api.flow_groups.set_flow_group_labels(

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -54,7 +54,7 @@ class TestSetFlowGroupLabels:
     async def test_set_flow_group_labels(self, flow_group_id):
         labels = ["meep", "morp"]
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert not flow_group.labels
+        assert len(flow_group.labels) == 0
 
         success = await api.flow_groups.set_flow_group_labels(
             flow_group_id=flow_group_id, labels=labels

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -36,7 +36,7 @@ class TestSetFlowGroupLabels:
             variables=dict(input=dict(flow_group_id=flow_group_id, labels=None)),
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert len(flow_group.labels) == 0
+        assert flow_group.labels is None
 
 
 class TestSetFlowGroupSchedule:

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -22,7 +22,7 @@ class TestSetFlowGroupLabels:
         )
         assert result.data.set_flow_group_labels.success is True
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == labels
+        assert flow_group.labels == set(labels)
 
     async def test_clear_flow_group_labels(self, run_query, flow_group_id):
         await models.FlowGroup.where(id=flow_group_id).update(

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -36,7 +36,7 @@ class TestSetFlowGroupLabels:
             variables=dict(input=dict(flow_group_id=flow_group_id, labels=None)),
         )
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels is None
+        assert len(flow_group.labels) == 0
 
 
 class TestSetFlowGroupSchedule:

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -22,7 +22,7 @@ class TestSetFlowGroupLabels:
         )
         assert result.data.set_flow_group_labels.success is True
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"labels"})
-        assert flow_group.labels == set(labels)
+        assert set(flow_group.labels) == set(labels)
 
     async def test_clear_flow_group_labels(self, run_query, flow_group_id):
         await models.FlowGroup.where(id=flow_group_id).update(


### PR DESCRIPTION
**Thanks for contributing to Prefect Server!**

Please describe your work and make sure your PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a changelog entry to the `changes/` directory (if appropriate)

Note that your PR will not be reviewed unless these two boxes are checked.

## What does this PR change?
Modifies the `resolve_set_flow_group_labels` resolver to dedupe the labels input.


## Why is this PR important?
Core already does this so Server should as well, duplicate labels are unnecessary. 

