### PR TITLE
Update apollo post-start to wait for graphql service

### DIFF
--- a/changes/pr41.yaml
+++ b/changes/pr41.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Set Apollo's `post-start.sh` script to wait for the GraphQL service's healthcheck - [#41](https://github.com/PrefectHQ/server/pull/41)"

--- a/services/apollo/post-start.sh
+++ b/services/apollo/post-start.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -eu
-curl -s $GRAPHQL_SERVICE_HOST:$GRAPHQL_SERVICE_PORT/health | grep $PREFECT_SERVER_VERSION && echo "Service Healthy" || kill 1
+
+while true; do
+    curl -s $GRAPHQL_SERVICE_HOST:$GRAPHQL_SERVICE_PORT/health | grep "ok" \
+        && echo "GraphQL service healthy!" && break
+    sleep 1
+done


### PR DESCRIPTION
**Thanks for contributing to Prefect Server!**

Please describe your work and make sure your PR:

- [x] adds new tests (if appropriate)
- [x] adds a changelog entry to the `changes/` directory (if appropriate)

Note that your PR will not be reviewed unless these two boxes are checked.

## What does this PR change?
Updates Apollo's `post-start.sh` to properly wait for the graphql service to be accessible.


## Why is this PR important?
The previous iteration of this did not properly function because we aren't currently providing a PREFECT_SERVER_VERSION to the image and `kill 1` wasn't exiting either.

