### PR TITLE
Update circle jobs to build and tag on cal-ver versioning schemes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
 
       - docker/publish:
           docker-password: DOCKER_HUB_PW
@@ -232,4 +232,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/


### PR DESCRIPTION
Server will begin versioning its "releases" (which are essentially just docker tags) with Calendar Versioning (YYYY-MM-DD(.*)).  This PR prepares our circle jobs to monitor for tags of this form.