### PR TITLE
Require explicit states for cloud hooks

### DIFF
--- a/changes/pr51.yaml
+++ b/changes/pr51.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+breaking:
+  - "Cloud hooks require explicit states - [#51](https://github.com/PrefectHQ/server/pull/51)"
+  - "Cloud hooks do not match state children - [#51](https://github.com/PrefectHQ/server/pull/51)"

--- a/changes/pr51.yaml
+++ b/changes/pr51.yaml
@@ -18,4 +18,4 @@
 
 breaking:
   - "Cloud hooks require explicit states - [#51](https://github.com/PrefectHQ/server/pull/51)"
-  - "Cloud hooks do not match state children - [#51](https://github.com/PrefectHQ/server/pull/51)"
+  - "Cloud hooks do not match state parents - [#51](https://github.com/PrefectHQ/server/pull/51)"

--- a/src/prefect_server/api/cloud_hooks.py
+++ b/src/prefect_server/api/cloud_hooks.py
@@ -25,23 +25,16 @@ CLOUD_HOOK_TYPES = {
     "PAGERDUTY",
 }
 
-STATE_PARENTS = {}
-for obj in prefect.engine.state.__dict__.values():
-    if isinstance(obj, type) and issubclass(obj, prefect.engine.state.State):
-        for parent in obj.mro():
-            if issubclass(parent, prefect.engine.state.State):
-                STATE_PARENTS.setdefault(obj.__name__.upper(), []).append(
-                    parent.__name__.upper()
-                )
+ALL_STATES = [s.__name__.upper() for s in prefect.engine.state.State.children()]
 
 
 @register_api("cloud_hooks.create_cloud_hook")
 async def create_cloud_hook(
     tenant_id: str,
     type: str,
+    states: List[str],
     config: dict = None,
     version_group_id: str = None,
-    states: List[str] = None,
     name=None,
 ) -> str:
     """
@@ -50,10 +43,10 @@ async def create_cloud_hook(
     Args:
         - tenant_id (str): the tenant ID
         - type (str): the cloud hook type
+        - states (List[str]): a list of states to monitor
         - config (str): the URL to which the webhook payload will be posted
         - version_group_id (str): the version group ID to monitor; if None, all flows
             from all version groups will trigger the webhook
-        - states (List[str]): a list of states to monitor; if None, all states are monitored
         - name (str): an optional name for the hook
 
     Returns:
@@ -66,6 +59,13 @@ async def create_cloud_hook(
     """
     if not tenant_id:
         raise ValueError("Invalid tenant ID")
+
+    if not states:
+        raise ValueError("Invalid states")
+
+    states = list({s.upper() for s in states})
+    if not all(s in ALL_STATES for s in states):
+        raise ValueError("Invalid states")
 
     if type not in CLOUD_HOOK_TYPES:
         raise ValueError("Invalid cloud hook type")
@@ -86,7 +86,11 @@ async def create_cloud_hook(
                 "Invalid config; expected `account_sid`, `auth_token`, `messaging_service_sid`, and `to`"
             )
     elif type == "PAGERDUTY":
-        if set(config or {}) != {"api_token", "routing_key", "severity"}:
+        if set(config or {}) != {
+            "api_token",
+            "routing_key",
+            "severity",
+        }:
             raise ValueError(
                 "Invalid config; expected `api_token`, `routing_key`, & `severity`"
             )
@@ -94,10 +98,6 @@ async def create_cloud_hook(
             raise ValueError(
                 "Invalid config; severity must be one of {info, warning, error, critical}"
             )
-    if states is not None:
-        states = list({s.upper() for s in states})
-        if not states or not all(state in STATE_PARENTS for state in states):
-            raise ValueError("Invalid states")
     return await models.CloudHook(
         tenant_id=tenant_id,
         version_group_id=version_group_id,
@@ -225,29 +225,21 @@ async def _get_matching_hooks(event: events.FlowRunStateChange) -> List[Box]:
     Retrieves cloud hooks that match either the flow or states of the supplied event.
     """
     state = event.state.state.upper()
+
     hooks = await models.CloudHook.where(
         {
+            "tenant_id": {"_eq": event.tenant.id},
             # the hook is active
             "active": {"_eq": True},
-            "tenant_id": {"_eq": event.tenant.id},
-            "_and": [
-                {
-                    # the hook either matches this version group id or all flows from all
-                    # version group IDs
-                    "_or": [
-                        {"version_group_id": {"_eq": event.flow.version_group_id}},
-                        {"version_group_id": {"_is_null": True}},
-                    ]
-                },
-                {
-                    # the hook either matches this state or all states
-                    "_or": [
-                        {"states": {"_has_keys_any": STATE_PARENTS.get(state, [])}},
-                        {"states": {"_is_null": True}},
-                    ]
-                },
+            # the hook matches the provided state
+            "states": {"_has_keys_any": event.state.state.upper()},
+            # the hook either matches this version group id or all flows from all
+            # version group IDs
+            "_or": [
+                {"version_group_id": {"_eq": event.flow.version_group_id}},
+                {"version_group_id": {"_is_null": True}},
             ],
-        }
+        },
     ).get({"id", "type", "config"})
 
     return hooks

--- a/src/prefect_server/graphql/cloud_hooks.py
+++ b/src/prefect_server/graphql/cloud_hooks.py
@@ -15,9 +15,9 @@ async def resolve_create_cloud_hook(
     hook_id = await api.cloud_hooks.create_cloud_hook(
         tenant_id=input["tenant_id"],
         type=input["type"],
+        states=input["states"],
         config=input.get("config"),
         version_group_id=input.get("version_group_id"),
-        states=input.get("states"),
         name=input.get("name"),
     )
 

--- a/src/prefect_server/graphql/schema/schema.graphql
+++ b/src/prefect_server/graphql/schema/schema.graphql
@@ -155,7 +155,7 @@ input create_cloud_hook_input {
   type: cloud_hook_type!
   name: String
   version_group_id: String
-  states: [String!]
+  states: [String!]!
   config: JSON
 }
 

--- a/tests/graphql/test_cloud_hooks.py
+++ b/tests/graphql/test_cloud_hooks.py
@@ -29,7 +29,10 @@ class TestCreateCloudHook:
             query=self.mutation,
             variables=dict(
                 input=dict(
-                    tenant_id=tenant_id, type="WEBHOOK", config={"url": "test-url"}
+                    tenant_id=tenant_id,
+                    type="WEBHOOK",
+                    config={"url": "test-url"},
+                    states=["FAILED"],
                 )
             ),
         )
@@ -40,7 +43,7 @@ class TestCreateCloudHook:
         assert hook.tenant_id == tenant_id
         assert hook.config == {"url": "test-url"}
         assert hook.version_group_id is None
-        assert hook.states is None
+        assert hook.states == ["FAILED"]
         assert hook.name is None
         assert hook.type == "WEBHOOK"
 
@@ -52,6 +55,7 @@ class TestCreateCloudHook:
                     tenant_id=tenant_id,
                     type="SLACK_WEBHOOK",
                     config={"url": "test-url"},
+                    states=["FAILED"],
                 )
             ),
         )
@@ -66,7 +70,12 @@ class TestCreateCloudHook:
         result = await run_query(
             query=self.mutation,
             variables=dict(
-                input=dict(tenant_id=tenant_id, type="PREFECT_MESSAGE", config={})
+                input=dict(
+                    tenant_id=tenant_id,
+                    type="PREFECT_MESSAGE",
+                    config={},
+                    states=["FAILED"],
+                )
             ),
         )
 
@@ -88,6 +97,7 @@ class TestCreateCloudHook:
                         "messaging_service_sid": "test_messaging_service_sid",
                         "to": ["+15555555555"],
                     },
+                    states=["FAILED"],
                 )
             ),
         )
@@ -115,6 +125,7 @@ class TestCreateCloudHook:
                         "routing_key": "test_routing_key",
                         "severity": "info",
                     },
+                    states=["FAILED"],
                 )
             ),
         )
@@ -217,7 +228,10 @@ class TestDeleteWebhook:
 
     async def test_delete_hook(self, run_query, tenant_id):
         hook_id = await api.cloud_hooks.create_cloud_hook(
-            tenant_id=tenant_id, type="WEBHOOK", config=dict(url="test-url")
+            tenant_id=tenant_id,
+            type="WEBHOOK",
+            config=dict(url="test-url"),
+            states=["FAILED"],
         )
 
         result = await run_query(
@@ -239,7 +253,10 @@ class TestSetCloudHookActive:
 
     async def test_set_hook_active(self, run_query, tenant_id):
         hook_id = await api.cloud_hooks.create_cloud_hook(
-            tenant_id=tenant_id, type="WEBHOOK", config=dict(url="test-url")
+            tenant_id=tenant_id,
+            type="WEBHOOK",
+            config=dict(url="test-url"),
+            states=["FAILED"],
         )
         await api.cloud_hooks.set_cloud_hook_inactive(hook_id)
 
@@ -263,7 +280,10 @@ class TestSetInactive:
     async def test_set_hook_inactive(self, run_query, tenant_id):
 
         hook_id = await api.cloud_hooks.create_cloud_hook(
-            tenant_id=tenant_id, type="WEBHOOK", config=dict(url="test-url")
+            tenant_id=tenant_id,
+            type="WEBHOOK",
+            config=dict(url="test-url"),
+            states=["FAILED"],
         )
 
         result = await run_query(
@@ -287,7 +307,10 @@ class TestTestWebhook:
     async def test_testing_invalid_hook_returns_error(self, run_query, tenant_id):
 
         hook_id = await api.cloud_hooks.create_cloud_hook(
-            tenant_id=tenant_id, type="WEBHOOK", config=dict(url="test.test")
+            tenant_id=tenant_id,
+            type="WEBHOOK",
+            config=dict(url="test.test"),
+            states=["FAILED"],
         )
 
         result = await run_query(
@@ -303,6 +326,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="WEBHOOK",
             config=dict(url="http://0.0.0.0:8100/hook"),
+            states=["FAILED"],
         )
 
         result = await run_query(
@@ -327,6 +351,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="WEBHOOK",
             config=dict(url="http://0.0.0.0:8100/hook"),
+            states=["SUCCESS"],
         )
 
         result = await run_query(
@@ -353,6 +378,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="WEBHOOK",
             config=dict(url="http://0.0.0.0:8100/hook"),
+            states=["FAILED"],
         )
 
         result = await run_query(
@@ -380,6 +406,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="SLACK_WEBHOOK",
             config={"url": "http://0.0.0.0:8100/hook"},
+            states=["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"],
         )
 
         await run_query(
@@ -408,6 +435,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="SLACK_WEBHOOK",
             config={"url": "http://0.0.0.0:8100/hook"},
+            states=["SUCCESS"],
         )
 
         await run_query(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->




## Changes
<!-- What does this PR change? -->
- require explicit states when creating cloud hooks
- cloud hooks no longer match state parents; they only match provided states




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
