### PR TITLE
Remove black dependency pin and reformat files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - checkout
       - run:
           name: Install Black
-          command: pip install "black==19.10b0"
+          command: pip install black
       - run:
           name: Run Black
           command: black --check .

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
 ]
 
 dev_requires = [
-    "black == 19.10b0",
+    "black",
     "asynctest >= 0.13, < 0.14",
     "pytest >= 5.0, < 6.0",
     "pytest-asyncio",

--- a/src/prefect_server/api/cloud_hooks.py
+++ b/src/prefect_server/api/cloud_hooks.py
@@ -76,12 +76,16 @@ async def create_cloud_hook(
         if set(config or {}) != {"url"}:
             raise ValueError("Invalid config; expected `url`")
     elif type == "TWILIO":
-        if set(config or {}) != {
-            "account_sid",
-            "auth_token",
-            "messaging_service_sid",
-            "to",
-        } or not config.get("to"):
+        if (
+            set(config or {})
+            != {
+                "account_sid",
+                "auth_token",
+                "messaging_service_sid",
+                "to",
+            }
+            or not config.get("to")
+        ):
             raise ValueError(
                 "Invalid config; expected `account_sid`, `auth_token`, `messaging_service_sid`, and `to`"
             )

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -11,7 +11,7 @@ from prefect.utilities.plugins import register_api
 async def set_flow_group_default_parameters(
     flow_group_id: str, parameters: dict
 ) -> bool:
-    """ Sets default value(s) for parameter(s) on a flow group
+    """Sets default value(s) for parameter(s) on a flow group
 
     Args:
         - flow_group_id (str): the ID of the flow group to update

--- a/src/prefect_server/api/logs.py
+++ b/src/prefect_server/api/logs.py
@@ -15,7 +15,7 @@ async def create_logs(logs: List[Dict[str, Any]]) -> str:
     Args:
         - logs (list): a list of log records represented as dictionaries, containing the following keys:
             `tenant_id` and `flow_run_id` and optionally containing task_run_id, timestamp, message, name, level and info.
-        
+
     Returns:
         - None
     """

--- a/src/prefect_server/api/messages.py
+++ b/src/prefect_server/api/messages.py
@@ -12,7 +12,10 @@ async def create_message(
         raise ValueError("Invalid message type.")
 
     return await models.Message(
-        tenant_id=tenant_id, type=type, text=text, content=content,
+        tenant_id=tenant_id,
+        type=type,
+        text=text,
+        content=content,
     ).insert()
 
 
@@ -45,7 +48,9 @@ async def create_requires_approval_message(task_run: models.TaskRun) -> None:
     }
 
     await create_message(
-        tenant_id=tenant_id, type="REQUIRES_APPROVAL", content=message_content,
+        tenant_id=tenant_id,
+        type="REQUIRES_APPROVAL",
+        content=message_content,
     )
 
 

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -283,7 +283,9 @@ async def get_or_create_mapped_task_run_children(
 
 
 @register_api("runs.update_flow_run_heartbeat")
-async def update_flow_run_heartbeat(flow_run_id: str,) -> None:
+async def update_flow_run_heartbeat(
+    flow_run_id: str,
+) -> None:
     """
     Updates the heartbeat of a flow run.
 
@@ -302,7 +304,9 @@ async def update_flow_run_heartbeat(flow_run_id: str,) -> None:
 
 
 @register_api("runs.update_task_run_heartbeat")
-async def update_task_run_heartbeat(task_run_id: str,) -> None:
+async def update_task_run_heartbeat(
+    task_run_id: str,
+) -> None:
     """
     Updates the heartbeat of a task run. Also sets the corresponding flow run heartbeat.
 

--- a/src/prefect_server/cli/database.py
+++ b/src/prefect_server/cli/database.py
@@ -156,7 +156,8 @@ def reset(unsafe, yes):
         if config.hasura.host not in hasura_hosts:
             click.secho(
                 "Failed safety check: bad 'hasura.host': '{}'\n  expected to be one of: {}".format(
-                    config.hasura.host, ",".join(repr(c) for c in hasura_hosts),
+                    config.hasura.host,
+                    ",".join(repr(c) for c in hasura_hosts),
                 ),
                 bg="red",
                 bold=True,
@@ -223,7 +224,8 @@ def reset(unsafe, yes):
         if not found_valid_candidate:
             click.secho(
                 "Failed safety check: bad 'hasura.db_url': '{}'\n  expected to contain one of: {}".format(
-                    config.hasura.db_url, ",".join(repr(c) for c in valid_candidates),
+                    config.hasura.db_url,
+                    ",".join(repr(c) for c in valid_candidates),
                 ),
                 bg="red",
                 bold=True,

--- a/src/prefect_server/cli/hasura.py
+++ b/src/prefect_server/cli/hasura.py
@@ -32,7 +32,8 @@ def apply_hasura_metadata(endpoint=None, metadata_path=None, verbose=True):
         metadata = yaml.load(f, Loader=yaml.SafeLoader)
 
     response = requests.post(
-        endpoint, json={"type": "replace_metadata", "args": metadata},
+        endpoint,
+        json={"type": "replace_metadata", "args": metadata},
     )
     try:
         response.raise_for_status()
@@ -103,7 +104,8 @@ def export_metadata(endpoint, metadata_path):
         click.secho("\nExporting Hasura metadata...")
         endpoint = os.path.join(endpoint, "v1", "query")
         response = requests.post(
-            endpoint, json={"type": "export_metadata", "args": {}},
+            endpoint,
+            json={"type": "export_metadata", "args": {}},
         )
         response.raise_for_status()
 
@@ -134,7 +136,8 @@ def drop_inconsistent_metadata(endpoint):
         click.secho("\nDropping inconsistent Hasura metadata...")
         endpoint = os.path.join(endpoint, "v1", "query")
         response = requests.post(
-            endpoint, json={"type": "drop_inconsistent_metadata", "args": {}},
+            endpoint,
+            json={"type": "drop_inconsistent_metadata", "args": {}},
         )
         response.raise_for_status()
 
@@ -163,7 +166,10 @@ def clear_metadata(endpoint):
     try:
         click.secho("\nClearing Hasura metadata...")
         endpoint = os.path.join(endpoint, "v1", "query")
-        response = requests.post(endpoint, json={"type": "clear_metadata", "args": {}},)
+        response = requests.post(
+            endpoint,
+            json={"type": "clear_metadata", "args": {}},
+        )
         response.raise_for_status()
         click.secho("\nFinished!", fg="green")
     except Exception as exc:
@@ -191,7 +197,8 @@ def reload_metadata(endpoint):
         click.secho("\nReloading Hasura metadata...")
         endpoint = os.path.join(endpoint, "v1", "query")
         response = requests.post(
-            endpoint, json={"type": "reload_metadata", "args": {}},
+            endpoint,
+            json={"type": "reload_metadata", "args": {}},
         )
         response.raise_for_status()
         click.secho("\nFinished!", fg="green")

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -523,7 +523,10 @@ class ModelQuery:
         if result:
             return result[0]
 
-    async def count(self, distinct_on: List[str] = None,) -> int:
+    async def count(
+        self,
+        distinct_on: List[str] = None,
+    ) -> int:
         """
         Counts the number of objects corresponding to the query's where clause.
 
@@ -545,7 +548,8 @@ class ModelQuery:
         query = {
             "query": {
                 with_args(
-                    f"count_query: {self.model.__hasura_type__}_aggregate", arguments,
+                    f"count_query: {self.model.__hasura_type__}_aggregate",
+                    arguments,
                 ): {"aggregate": "count"}
             }
         }

--- a/src/prefect_server/graphql/runs.py
+++ b/src/prefect_server/graphql/runs.py
@@ -99,6 +99,8 @@ async def resolve_get_runs_in_queue(
     labels = input.get("labels", [])
     labels.sort()
     result = await api.runs.get_runs_in_queue(
-        tenant_id=input["tenant_id"], before=input.get("before"), labels=labels,
+        tenant_id=input["tenant_id"],
+        before=input.get("before"),
+        labels=labels,
     )
     return {"flow_run_ids": result}

--- a/src/prefect_server/services/towel/__main__.py
+++ b/src/prefect_server/services/towel/__main__.py
@@ -7,7 +7,9 @@ from prefect_server.services.towel.zombie_killer import ZombieKiller
 
 async def run_towel():
     await asyncio.gather(
-        Lazarus().run(), Scheduler().run(), ZombieKiller().run(),
+        Lazarus().run(),
+        Scheduler().run(),
+        ZombieKiller().run(),
     )
 
 

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -134,7 +134,8 @@ class Lazarus(LoopService):
                 )
                 # Set flow run state to failed
                 await prefect.api.states.set_flow_run_state(
-                    flow_run_id=fr.id, state=Failed(message=message),
+                    flow_run_id=fr.id,
+                    state=Failed(message=message),
                 )
                 # log flow run state change
                 await prefect.api.logs.create_logs(

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -38,7 +38,9 @@ class Scheduler(LoopService):
                     "archived": {"_eq": False},
                 }
             ).get(
-                selection_set={"id",},
+                selection_set={
+                    "id",
+                },
                 order_by=[
                     {
                         "flow_runs_aggregate": {

--- a/src/prefect_server/services/towel/zombie_killer.py
+++ b/src/prefect_server/services/towel/zombie_killer.py
@@ -63,7 +63,8 @@ class ZombieKiller(LoopService):
             try:
                 message = "No heartbeat detected from the flow run; marking the run as failed."
                 await prefect.api.states.set_flow_run_state(
-                    flow_run_id=fr.id, state=Failed(message=message),
+                    flow_run_id=fr.id,
+                    state=Failed(message=message),
                 )
 
                 # log the state change to the flow run
@@ -179,7 +180,8 @@ class ZombieKiller(LoopService):
                 else:
                     message = "No heartbeat detected from the remote task; marking the run as failed."
                     await prefect.api.states.set_task_run_state(
-                        task_run_id=tr.id, state=Failed(message=message),
+                        task_run_id=tr.id,
+                        state=Failed(message=message),
                     )
 
                 # log the state change to the task run

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -346,7 +346,9 @@ class TestCreateFlow:
         assert flow_id
 
     async def test_create_flow_assigns_description(
-        self, project_id, flow,
+        self,
+        project_id,
+        flow,
     ):
         description = "test"
         flow_id = await api.flows.create_flow(
@@ -672,7 +674,8 @@ class TestDeleteFlow:
 
     async def test_delete_flow_deletes_flow_runs(self, flow_id, flow_run_id):
         await api.states.set_flow_run_state(
-            flow_run_id=flow_run_id, state=prefect.engine.state.Scheduled(),
+            flow_run_id=flow_run_id,
+            state=prefect.engine.state.Scheduled(),
         )
 
         assert await models.FlowRun.exists(flow_run_id)
@@ -1033,14 +1036,16 @@ class TestScheduleRuns:
         assert await api.flows.schedule_flow_runs(flow_id) == []
 
     async def test_schedule_runs_doesnt_run_for_archived_flow(
-        self, flow_id,
+        self,
+        flow_id,
     ):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         await api.flows.archive_flow(flow_id)
         assert await api.flows.schedule_flow_runs(flow_id) == []
 
     async def test_schedule_runs_twice_doesnt_create_new_runs(
-        self, flow_id,
+        self,
+        flow_id,
     ):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert len(await api.flows.schedule_flow_runs(flow_id)) == 10

--- a/tests/api/test_logs.py
+++ b/tests/api/test_logs.py
@@ -37,7 +37,13 @@ async def test_create_logs_with_task_run_id(tenant_id, flow_run_id, task_run_id)
     logs_count = await models.Log.where(where_clause).count()
 
     await api.logs.create_logs(
-        [dict(tenant_id=tenant_id, flow_run_id=flow_run_id, task_run_id=task_run_id,)]
+        [
+            dict(
+                tenant_id=tenant_id,
+                flow_run_id=flow_run_id,
+                task_run_id=task_run_id,
+            )
+        ]
     )
 
     assert await models.Log.where(where_clause).count() == logs_count + 1

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -31,7 +31,9 @@ class TestCreateUpdate:
     async def test_create_message_fails_with_invalid_type(self, tenant_id):
         with pytest.raises(ValueError, match="Invalid message type."):
             await api.messages.create_message(
-                type="blah", content=dict(text="blah"), tenant_id=tenant_id,
+                type="blah",
+                content=dict(text="blah"),
+                tenant_id=tenant_id,
             )
 
 

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -73,7 +73,8 @@ class TestSetProjectName:
         assert result is False
 
     @pytest.mark.parametrize(
-        "bad_value", [None, ""],
+        "bad_value",
+        [None, ""],
     )
     async def test_set_project_name_fails_if_none(self, bad_value):
         with pytest.raises(ValueError, match="Invalid project ID"):
@@ -99,7 +100,8 @@ class TestSetProjectDescription:
         assert result is False
 
     @pytest.mark.parametrize(
-        "bad_value", [None, ""],
+        "bad_value",
+        [None, ""],
     )
     async def test_set_project_description_fails_if_none(self, bad_value):
         with pytest.raises(ValueError, match="Invalid project ID"):
@@ -121,7 +123,8 @@ class TestDeleteProjects:
         assert result is False
 
     @pytest.mark.parametrize(
-        "bad_value", [None, ""],
+        "bad_value",
+        [None, ""],
     )
     async def test_delete_project_fails_if_none(self, bad_value):
         with pytest.raises(ValueError, match="Invalid project ID"):

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -387,7 +387,9 @@ class TestGetTaskRunInfo:
         )
         await api.states.set_task_run_state(tr_id, state=Success())
 
-        tr = await models.TaskRun.where(id=tr_id).first({"state", "serialized_state"},)
+        tr = await models.TaskRun.where(id=tr_id).first(
+            {"state", "serialized_state"},
+        )
         assert tr.state == "Success"
         assert tr.serialized_state["type"] == "Success"
 
@@ -706,7 +708,8 @@ class TestDeleteFlowRuns:
         assert result is False
 
     @pytest.mark.parametrize(
-        "bad_value", [None, ""],
+        "bad_value",
+        [None, ""],
     )
     async def test_delete_flow_run_fails_if_none(self, bad_value):
         with pytest.raises(ValueError, match="Invalid flow run ID"):

--- a/tests/api/test_tenants.py
+++ b/tests/api/test_tenants.py
@@ -131,7 +131,8 @@ class TestDeleteTenant:
         assert result is False
 
     @pytest.mark.parametrize(
-        "bad_value", [None, ""],
+        "bad_value",
+        [None, ""],
     )
     async def test_delete_tenant_fails_if_none(self, bad_value):
         with pytest.raises(ValueError, match="Invalid tenant ID"):

--- a/tests/database/test_flow_run_insert_trigger.py
+++ b/tests/database/test_flow_run_insert_trigger.py
@@ -23,7 +23,9 @@ async def db_flow_id(project_id):
 class TestFlowRunInsertTrigger:
     async def test_insert_flow_run_creates_task_runs(self, db_flow_id):
         # create a flow run
-        flow_run_id = await models.FlowRun(flow_id=db_flow_id,).insert()
+        flow_run_id = await models.FlowRun(
+            flow_id=db_flow_id,
+        ).insert()
         # retrieve the task runs associated with the flow run
         task_runs = await models.TaskRun.where(
             {"flow_run_id": {"_eq": flow_run_id}}

--- a/tests/database/test_flow_traversal.py
+++ b/tests/database/test_flow_traversal.py
@@ -19,7 +19,7 @@ async def flow_id(project_id):
              7 -> 8 -> 9 -> 10
            /
         6
-    
+
                  11
     """
 
@@ -49,7 +49,9 @@ async def flow_id(project_id):
     )
 
 
-async def query_downstream(*ids,):
+async def query_downstream(
+    *ids,
+):
     return await prefect.plugins.hasura.client.execute(
         {
             "query": {
@@ -68,7 +70,9 @@ async def query_downstream(*ids,):
     )
 
 
-async def query_upstream(*ids,):
+async def query_upstream(
+    *ids,
+):
     return await prefect.plugins.hasura.client.execute(
         {
             "query": {

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -23,7 +23,10 @@ def test_alembic_single_head():
 
 
 async def test_full_migration_downgrade_works_with_data_in_db(
-    flow_id, task_run_id, task_run_id_2, task_run_id_3,
+    flow_id,
+    task_run_id,
+    task_run_id_2,
+    task_run_id_3,
 ):
     """
     Tests that downgrade migrations work when the database has data in it
@@ -37,7 +40,11 @@ async def test_full_migration_downgrade_works_with_data_in_db(
 
 @pytest.mark.parametrize("n", [1, 2, 3])
 async def test_recent_migration_upgrades_work_with_data_in_db(
-    flow_id, task_run_id, task_run_id_2, task_run_id_3, n,
+    flow_id,
+    task_run_id,
+    task_run_id_2,
+    task_run_id_3,
+    n,
 ):
     """
     Tests that the last N upgrades work with data in the database. Note that this isn't

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -175,7 +175,10 @@ class TestORM:
     async def test_insert_selection_set(self):
         result = Box(
             await models.Project(name="test").insert(
-                selection_set={"affected_rows": True, "returning": {"created", "name"},}
+                selection_set={
+                    "affected_rows": True,
+                    "returning": {"created", "name"},
+                }
             )
         )
         assert result.affected_rows == 1
@@ -305,7 +308,8 @@ class TestModelQuery:
         assert set(p.id for p in flows) == set(flow_ids)
 
     async def test_get_selection_set(
-        self, flow_ids,
+        self,
+        flow_ids,
     ):
 
         flows = await orm.ModelQuery(model=models.Project).get(selection_set="name")
@@ -320,17 +324,27 @@ class TestModelQuery:
         assert isinstance(flow, models.Project)
 
     async def test_count(
-        self, flow_ids,
+        self,
+        flow_ids,
     ):
         assert await orm.ModelQuery(model=models.Project, where={}).count() == 3
 
     async def test_count_where(
-        self, flow_ids,
+        self,
+        flow_ids,
     ):
-        assert await models.Project.where({"name": {"_neq": "f2"},}).count() == 2
+        assert (
+            await models.Project.where(
+                {
+                    "name": {"_neq": "f2"},
+                }
+            ).count()
+            == 2
+        )
 
     async def test_update(
-        self, flow_ids,
+        self,
+        flow_ids,
     ):
         await models.Project.where({"id": {"_eq": flow_ids[0]}}).update(
             set=dict(name="test")
@@ -339,7 +353,8 @@ class TestModelQuery:
         assert names == {"test", "f2", "f3"}
 
     async def test_delete(
-        self, flow_ids,
+        self,
+        flow_ids,
     ):
         await models.Project.where({"id": {"_eq": flow_ids[0]}}).delete()
         names = set(p.name for p in await models.Project.where({}).get("name"))

--- a/tests/database/test_run_timing_info_triggers.py
+++ b/tests/database/test_run_timing_info_triggers.py
@@ -22,14 +22,37 @@ async def reset_states(flow_run_id, task_run_id):
 
 class TestFlowRunStateTrigger:
     async def test_inserting_non_running_states_has_no_effect(self, flow_run_id):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
-                models.FlowRunState(**details, version=1, state="Scheduled",),
-                models.FlowRunState(**details, version=2, state="Failed",),
-                models.FlowRunState(**details, version=3, state="Retrying",),
-                models.FlowRunState(**details, version=4, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=1,
+                    state="Scheduled",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -41,14 +64,37 @@ class TestFlowRunStateTrigger:
         assert run.duration is None
 
     async def test_inserting_running_state_has_effect(self, flow_run_id):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
-                models.FlowRunState(**details, version=1, state="Running",),
-                models.FlowRunState(**details, version=2, state="Failed",),
-                models.FlowRunState(**details, version=3, state="Retrying",),
-                models.FlowRunState(**details, version=4, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=1,
+                    state="Running",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -60,18 +106,43 @@ class TestFlowRunStateTrigger:
         assert run.duration is not None
 
     async def test_inserting_running_state_later_has_effect(self, flow_run_id):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
-                models.FlowRunState(**details, version=2, state="Failed",),
-                models.FlowRunState(**details, version=3, state="Retrying",),
-                models.FlowRunState(**details, version=4, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
         await models.FlowRunState.insert_many(
-            [models.FlowRunState(**details, version=1, state="Running",),]
+            [
+                models.FlowRunState(
+                    **details,
+                    version=1,
+                    state="Running",
+                ),
+            ]
         )
 
         run = await models.FlowRun.where(id=flow_run_id).first(
@@ -82,20 +153,35 @@ class TestFlowRunStateTrigger:
         assert run.duration is not None
 
     async def test_start_and_end_from_running_state(self, flow_run_id):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
 
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.FlowRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.FlowRunState(**details, version=2, state="Failed", timestamp=et),
-                models.FlowRunState(**details, version=3, state="Retrying",),
-                models.FlowRunState(**details, version=4, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.FlowRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -107,13 +193,20 @@ class TestFlowRunStateTrigger:
         assert run.duration == (et - st).as_timedelta()
 
     async def test_no_end_if_running_is_last_state(self, flow_run_id):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
 
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.FlowRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
@@ -128,9 +221,13 @@ class TestFlowRunStateTrigger:
         assert run.duration is None
 
     async def test_start_and_end_from_multiple_running_states(
-        self, flow_run_id,
+        self,
+        flow_run_id,
     ):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
@@ -138,15 +235,27 @@ class TestFlowRunStateTrigger:
 
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.FlowRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.FlowRunState(**details, version=2, state="Failed"),
-                models.FlowRunState(**details, version=3, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
                 models.FlowRunState(**details, version=4, state="Running"),
                 models.FlowRunState(**details, version=5, state="Failed"),
-                models.FlowRunState(**details, version=6, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=6,
+                    state="Retrying",
+                ),
                 models.FlowRunState(**details, version=7, state="Running"),
                 models.FlowRunState(
                     **details, version=8, state="Success", timestamp=et
@@ -165,9 +274,13 @@ class TestFlowRunStateTrigger:
         assert run.duration == (et - st).as_timedelta()
 
     async def test_version_order_determines_timestamp(
-        self, flow_run_id,
+        self,
+        flow_run_id,
     ):
-        details = dict(flow_run_id=flow_run_id, serialized_state={},)
+        details = dict(
+            flow_run_id=flow_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
@@ -175,15 +288,27 @@ class TestFlowRunStateTrigger:
 
         await models.FlowRunState.insert_many(
             [
-                models.FlowRunState(**details, version=0, state="Pending",),
+                models.FlowRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.FlowRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.FlowRunState(**details, version=2, state="Failed"),
-                models.FlowRunState(**details, version=3, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
                 models.FlowRunState(**details, version=4, state="Running"),
                 models.FlowRunState(**details, version=6, state="Failed"),
-                models.FlowRunState(**details, version=7, state="Retrying",),
+                models.FlowRunState(
+                    **details,
+                    version=7,
+                    state="Retrying",
+                ),
                 models.FlowRunState(**details, version=8, state="Running"),
                 models.FlowRunState(
                     **details, version=5, state="Success", timestamp=not_et
@@ -204,14 +329,37 @@ class TestFlowRunStateTrigger:
 
 class TestTaskRunStateTrigger:
     async def test_inserting_non_running_states_has_no_effect(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
-                models.TaskRunState(**details, version=1, state="Scheduled",),
-                models.TaskRunState(**details, version=2, state="Failed",),
-                models.TaskRunState(**details, version=3, state="Retrying",),
-                models.TaskRunState(**details, version=4, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=1,
+                    state="Scheduled",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -224,14 +372,37 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 0
 
     async def test_inserting_running_state_has_effect(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
-                models.TaskRunState(**details, version=1, state="Running",),
-                models.TaskRunState(**details, version=2, state="Failed",),
-                models.TaskRunState(**details, version=3, state="Retrying",),
-                models.TaskRunState(**details, version=4, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=1,
+                    state="Running",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -244,18 +415,43 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 1
 
     async def test_inserting_running_state_later_has_effect(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
-                models.TaskRunState(**details, version=2, state="Failed",),
-                models.TaskRunState(**details, version=3, state="Retrying",),
-                models.TaskRunState(**details, version=4, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=2,
+                    state="Failed",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
         await models.TaskRunState.insert_many(
-            [models.TaskRunState(**details, version=1, state="Running",),]
+            [
+                models.TaskRunState(
+                    **details,
+                    version=1,
+                    state="Running",
+                ),
+            ]
         )
 
         run = await models.TaskRun.where(id=task_run_id).first(
@@ -267,20 +463,35 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 1
 
     async def test_start_and_end_from_running_state(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
 
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.TaskRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.TaskRunState(**details, version=2, state="Failed", timestamp=et),
-                models.TaskRunState(**details, version=3, state="Retrying",),
-                models.TaskRunState(**details, version=4, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
+                models.TaskRunState(
+                    **details,
+                    version=4,
+                    state="Retrying",
+                ),
             ]
         )
 
@@ -293,13 +504,20 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 1
 
     async def test_no_end_if_running_is_last_state(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
 
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.TaskRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
@@ -314,7 +532,10 @@ class TestTaskRunStateTrigger:
         assert run.duration is None
 
     async def test_start_and_end_from_multiple_running_states(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
@@ -322,15 +543,27 @@ class TestTaskRunStateTrigger:
 
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.TaskRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.TaskRunState(**details, version=2, state="Failed"),
-                models.TaskRunState(**details, version=3, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
                 models.TaskRunState(**details, version=4, state="Running"),
                 models.TaskRunState(**details, version=5, state="Failed"),
-                models.TaskRunState(**details, version=6, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=6,
+                    state="Retrying",
+                ),
                 models.TaskRunState(**details, version=7, state="Running"),
                 models.TaskRunState(
                     **details, version=8, state="Success", timestamp=et
@@ -350,7 +583,10 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 3
 
     async def test_version_order_determines_timestamp(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
@@ -358,15 +594,27 @@ class TestTaskRunStateTrigger:
 
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.TaskRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.TaskRunState(**details, version=2, state="Failed"),
-                models.TaskRunState(**details, version=3, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
                 models.TaskRunState(**details, version=4, state="Running"),
                 models.TaskRunState(**details, version=6, state="Failed"),
-                models.TaskRunState(**details, version=7, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=7,
+                    state="Retrying",
+                ),
                 models.TaskRunState(**details, version=8, state="Running"),
                 models.TaskRunState(
                     **details, version=5, state="Success", timestamp=not_et
@@ -386,7 +634,10 @@ class TestTaskRunStateTrigger:
         assert run.run_count == 3
 
     async def test_looping_doesnt_inflate_run_count(self, task_run_id):
-        details = dict(task_run_id=task_run_id, serialized_state={},)
+        details = dict(
+            task_run_id=task_run_id,
+            serialized_state={},
+        )
 
         st = pendulum.now("UTC")
         et = pendulum.now("UTC").add(days=1)
@@ -394,12 +645,20 @@ class TestTaskRunStateTrigger:
 
         await models.TaskRunState.insert_many(
             [
-                models.TaskRunState(**details, version=0, state="Pending",),
+                models.TaskRunState(
+                    **details,
+                    version=0,
+                    state="Pending",
+                ),
                 models.TaskRunState(
                     **details, version=1, state="Running", timestamp=st
                 ),
                 models.TaskRunState(**details, version=2, state="Failed"),
-                models.TaskRunState(**details, version=3, state="Retrying",),
+                models.TaskRunState(
+                    **details,
+                    version=3,
+                    state="Retrying",
+                ),
                 models.TaskRunState(**details, version=4, state="Running"),
                 models.TaskRunState(**details, version=5, state="Looped"),
                 models.TaskRunState(**details, version=6, state="Running"),

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -149,7 +149,8 @@ class TestSetFlowGroupSchedule:
             query=self.mutation,
             variables=dict(
                 input=dict(
-                    flow_group_id=flow_group_id, interval_clocks=[{"interval": 60}],
+                    flow_group_id=flow_group_id,
+                    interval_clocks=[{"interval": 60}],
                 )
             ),
         )

--- a/tests/graphql/test_flows.py
+++ b/tests/graphql/test_flows.py
@@ -324,7 +324,8 @@ class TestDeleteFlow:
 
     async def test_delete_flow(self, run_query, flow_id):
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=flow_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=flow_id)),
         )
         assert not await models.Flow.exists(flow_id)
 
@@ -342,7 +343,8 @@ class TestArchiveFlow:
         flow = await models.Flow.where(id=flow_id).first({"archived"})
         assert not flow.archived
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=flow_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=flow_id)),
         )
         # confirm the payload is as expected
         assert result.data.archive_flow.success is True
@@ -352,14 +354,16 @@ class TestArchiveFlow:
 
     async def test_archive_nonexistent_flow(self, run_query):
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=str(uuid.uuid4()))),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=str(uuid.uuid4()))),
         )
         # confirm the payload is as expected
         assert result.data.archive_flow.success is False
 
     async def test_archive_flow_with_none_flow_id(self, run_query):
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=None)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=None)),
         )
         assert (
             "Expected non-nullable type UUID! not to be None."
@@ -477,7 +481,8 @@ class TestUpdateFlowLazarus:
 
     async def test_enable_flow_lazarus_where_flow_id_none(self, run_query):
         result = await run_query(
-            query=self.enable_lazarus_mutation, variables=dict(input={"flow_id": None}),
+            query=self.enable_lazarus_mutation,
+            variables=dict(input={"flow_id": None}),
         )
         # confirm there was an error, and that it was related to flow_id=None
         assert "got invalid value None at 'input.flow_id'" in result.errors[0].message
@@ -507,7 +512,8 @@ class TestUpdateFlowVersionLocking:
         assert flow_group.settings == {}
 
         result = await run_query(
-            query=self.enable_lock_mutation, variables=dict(input={"flow_id": flow_id}),
+            query=self.enable_lock_mutation,
+            variables=dict(input={"flow_id": flow_id}),
         )
 
         assert result.data.enable_flow_version_lock.success is True
@@ -532,14 +538,16 @@ class TestUpdateFlowVersionLocking:
 
     async def test_enable_flow_version_lock_where_flow_id_none(self, run_query):
         result = await run_query(
-            query=self.enable_lock_mutation, variables=dict(input={"flow_id": None}),
+            query=self.enable_lock_mutation,
+            variables=dict(input={"flow_id": None}),
         )
         # confirm there was an error, and that it was related to flow_id=None
         assert "got invalid value None at 'input.flow_id'" in result.errors[0].message
 
     async def test_disable_flow_version_lock_where_flow_id_none(self, run_query):
         result = await run_query(
-            query=self.disable_lock_mutation, variables=dict(input={"flow_id": None}),
+            query=self.disable_lock_mutation,
+            variables=dict(input={"flow_id": None}),
         )
         # confirm there was an error, and that it was related to flow_id=None
         assert "got invalid value None at 'input.flow_id'" in result.errors[0].message
@@ -558,7 +566,8 @@ class TestSetScheduleActive:
         await api.flows.set_schedule_inactive(flow_id=flow_id)
 
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=flow_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=flow_id)),
         )
 
         assert result.data.set_schedule_active.success is True
@@ -580,7 +589,8 @@ class TestSetScheduleInactive:
 
         # set inactive
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_id=flow_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_id=flow_id)),
         )
         assert result.data.set_schedule_inactive.success is True
         flow = await models.Flow.where(id=flow_id).first({"is_schedule_active"})

--- a/tests/graphql/test_logs.py
+++ b/tests/graphql/test_logs.py
@@ -18,7 +18,8 @@ class TestWriteRunLogs:
 
         logs = [dict(flow_run_id=flow_run_id, message="test") for _ in range(10)]
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(logs=logs)),
+            query=self.mutation,
+            variables=dict(input=dict(logs=logs)),
         )
 
         assert result.data.write_run_logs.success
@@ -37,7 +38,8 @@ class TestWriteRunLogs:
             for _ in range(14)
         ]
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(logs=logs)),
+            query=self.mutation,
+            variables=dict(input=dict(logs=logs)),
         )
         assert result.data.write_run_logs.success
 
@@ -64,7 +66,8 @@ class TestWriteRunLogs:
         )
         logs = [payload for _ in range(6)]
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(logs=logs)),
+            query=self.mutation,
+            variables=dict(input=dict(logs=logs)),
         )
 
         assert result.data.write_run_logs.success
@@ -115,7 +118,8 @@ class TestWriteRunLogs:
             for i in range(4)
         ]
         await run_query(
-            query=self.mutation, variables=dict(input=dict(logs=payloads)),
+            query=self.mutation,
+            variables=dict(input=dict(logs=payloads)),
         )
 
         await asyncio.sleep(0.5)
@@ -138,7 +142,8 @@ class TestWriteRunLogs:
         logs = [dict(flow_run_id=flow_run_id, message="test") for _ in range(9)]
         logs.append(dict(flow_run_id=None, message="test"))
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(logs=logs)),
+            query=self.mutation,
+            variables=dict(input=dict(logs=logs)),
         )
 
         assert result.errors

--- a/tests/graphql/test_projects.py
+++ b/tests/graphql/test_projects.py
@@ -63,7 +63,8 @@ class TestDeleteProject:
 
     async def test_delete_project(self, run_query, project_id):
         result = await run_query(
-            query=self.mutation, variables=dict(input=(dict(project_id=project_id))),
+            query=self.mutation,
+            variables=dict(input=(dict(project_id=project_id))),
         )
         assert result.data.delete_project.success
         assert not await models.Project.exists(project_id)
@@ -95,7 +96,8 @@ class TestSetProjectName:
         assert project.name == "foo-bar"
 
     async def test_set_project_name_with_bad_project_id(
-        self, run_query,
+        self,
+        run_query,
     ):
         result = await run_query(
             query=self.mutation,
@@ -136,7 +138,8 @@ class TestSetProjectDescription:
         assert project.description == "foo-bar"
 
     async def test_set_project_description_with_bad_project_id(
-        self, run_query,
+        self,
+        run_query,
     ):
         result = await run_query(
             query=self.mutation,

--- a/tests/graphql/test_runs.py
+++ b/tests/graphql/test_runs.py
@@ -272,7 +272,8 @@ class TestUpdateFlowRunHeartbeat:
     async def test_update_flow_run_heartbeat(self, run_query, flow_run_id):
         dt = pendulum.now()
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_run_id=flow_run_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_run_id=flow_run_id)),
         )
 
         # sleep to give the concurrent update a chance to run
@@ -305,7 +306,8 @@ class TestUpdateTaskRunHeartbeat:
     async def test_update_task_run_heartbeat(self, run_query, task_run_id):
         dt = pendulum.now()
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(task_run_id=task_run_id)),
+            query=self.mutation,
+            variables=dict(input=dict(task_run_id=task_run_id)),
         )
 
         # sleep to give the concurrent update a chance to run
@@ -338,7 +340,8 @@ class TestDeleteFlowRun:
 
     async def test_delete_flow_run(self, run_query, flow_run_id):
         result = await run_query(
-            query=self.mutation, variables=dict(input=dict(flow_run_id=flow_run_id)),
+            query=self.mutation,
+            variables=dict(input=dict(flow_run_id=flow_run_id)),
         )
 
         assert result.data.delete_flow_run.success
@@ -399,7 +402,10 @@ class TestGetRunsInQueue:
     """
 
     async def test_get_runs_in_queue(
-        self, run_query, tenant_id, flow_run_id,
+        self,
+        run_query,
+        tenant_id,
+        flow_run_id,
     ):
         await api.states.set_flow_run_state(
             flow_run_id=flow_run_id,
@@ -412,7 +418,11 @@ class TestGetRunsInQueue:
         assert flow_run_id in result.data.get_runs_in_queue.flow_run_ids
 
     async def test_get_runs_in_queue_uses_labels(
-        self, run_query, tenant_id, flow_run_id, labeled_flow_run_id,
+        self,
+        run_query,
+        tenant_id,
+        flow_run_id,
+        labeled_flow_run_id,
     ):
         await api.states.set_flow_run_state(
             flow_run_id=labeled_flow_run_id,
@@ -427,7 +437,11 @@ class TestGetRunsInQueue:
         assert flow_run_id not in result.data.get_runs_in_queue.flow_run_ids
 
     async def test_get_runs_in_queue_uses_labels_and_filters_for_subset(
-        self, run_query, tenant_id, flow_run_id, labeled_flow_run_id,
+        self,
+        run_query,
+        tenant_id,
+        flow_run_id,
+        labeled_flow_run_id,
     ):
         await api.states.set_flow_run_state(
             flow_run_id=labeled_flow_run_id,
@@ -464,7 +478,10 @@ class TestGetRunsInQueue:
         assert flow_run_id not in result.data.get_runs_in_queue.flow_run_ids
 
     async def test_get_runs_in_queue_before_certain_time(
-        self, run_query, tenant_id, flow_run_id,
+        self,
+        run_query,
+        tenant_id,
+        flow_run_id,
     ):
         await api.states.set_flow_run_state(
             flow_run_id=flow_run_id,
@@ -483,7 +500,10 @@ class TestGetRunsInQueue:
         assert flow_run_id not in result.data.get_runs_in_queue.flow_run_ids
 
     async def test_multiple_runs_in_queue_before_certain_time(
-        self, run_query, tenant_id, flow_id,
+        self,
+        run_query,
+        tenant_id,
+        flow_id,
     ):
         now = pendulum.now("utc")
 

--- a/tests/graphql/test_states.py
+++ b/tests/graphql/test_states.py
@@ -542,7 +542,8 @@ class TestCancelFlowRun:
         )
 
         result = await run_query(
-            query=self.mutation, variables={"input": {"flow_run_id": flow_run_id}},
+            query=self.mutation,
+            variables={"input": {"flow_run_id": flow_run_id}},
         )
 
         assert result.data.cancel_flow_run.state == res_state

--- a/tests/services/test_zombie_killer.py
+++ b/tests/services/test_zombie_killer.py
@@ -342,7 +342,11 @@ class TestZombieKillerRetries:
 
     @pytest.mark.parametrize("state", ["Failed", "Cancelling"])
     async def test_zombie_killer_does_not_retry_if_flow_run_is_not_running(
-        self, flow_run_id, task_id, task_run_id, state,
+        self,
+        flow_run_id,
+        task_id,
+        task_run_id,
+        state,
     ):
         await api.states.set_task_run_state(
             task_run_id, state=prefect.engine.state.Running()


### PR DESCRIPTION
This removes the black pin and reformats files. This pin was causing issues in development because `prefect` is up to date on versions.

cc @cicdw Why was this pinned?