### PR TITLE
Fix bug with lazarus rescheduling flows with active tasks

### DIFF
--- a/changes/pr67.yaml
+++ b/changes/pr67.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Ensure Lazarus ignores flow runs with active tasks - [#67](https://github.com/PrefectHQ/server/pull/67)"

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -47,12 +47,12 @@ class Lazarus(LoopService):
             "state": {"_in": ["Running", "Submitted"]},
             # that were last updated some time ago
             "heartbeat": {"_lte": str(heartbeat_cutoff)},
-            "_not": {
-                "_or": [
-                    # but have no task runs in a near-running state
-                    {"task_runs": {"state": {"_in": LAZARUS_EXCLUDE}}},
-                    # and whose do not have heartbeats or lazarus enabled
-                    {
+            "_and": [
+                # but have no task runs in a near-running state
+                {"_not": {"task_runs": {"state": {"_in": LAZARUS_EXCLUDE}}}},
+                # and whose do not have heartbeats or lazarus enabled
+                {
+                    "_not": {
                         "flow": {
                             "flow_group": {
                                 "_or": [
@@ -69,9 +69,9 @@ class Lazarus(LoopService):
                                 ]
                             }
                         }
-                    },
-                ]
-            },
+                    }
+                },
+            ],
         }
 
     async def reschedule_flow_runs(
@@ -83,7 +83,6 @@ class Lazarus(LoopService):
         where_clause = await self.get_flow_runs_where_clause(
             heartbeat_cutoff=heartbeat_cutoff
         )
-        breakpoint()
         flow_runs = await models.FlowRun.where(where_clause).get(
             selection_set={"id", "version", "tenant_id", "times_resurrected"},
             order_by={"updated": EnumValue("asc")},

--- a/tests/services/test_lazarus.py
+++ b/tests/services/test_lazarus.py
@@ -210,7 +210,7 @@ async def test_lazarus_doesnt_restart_flow_run_with_active_tasks(
     await api.states.set_task_run_state(task_run_id, state=task_state)
 
     # set old heartbeat
-    await models.FlowRun.where(id=task_run_id).update(
+    await models.FlowRun.where(id=flow_run_id).update(
         set={"heartbeat": pendulum.now("utc").subtract(hours=1)}
     )
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Ensures that lazarus will not reschedule flow runs when they have active task runs



## Changes
<!-- What does this PR change? -->
Due to a duplicate `"_not"` key in the `where_clause` dictionary, Lazarus was not enforcing part of its query that ignores flow runs that have active tasks.

Compounding this, the test for this situation provided the wrong id when setting an old heartbeat, and so it mistakenly showed this behavior was being enforced when it was not.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
