### PR TITLE
Fix setting schedules to active

### DIFF
--- a/changes/issue86.yaml
+++ b/changes/issue86.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix and consolidate behavior for active schedules - [#86](https://github.com/PrefectHQ/server/issues/86)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -153,17 +153,6 @@ async def create_flow(
         raise ValueError("Invalid project.")
     tenant_id = project.tenant_id  # type: ignore
 
-    # check required parameters - can't load a flow that has required params and a shcedule
-    # NOTE: if we allow schedules to be set via UI in the future, we might skip or
-    # refactor this check
-    required_parameters = [p for p in flow.parameters if p.required]
-    if flow.schedule is not None and required_parameters:
-        required_names = {p.name for p in required_parameters}
-        if not all(
-            [required_names <= set(c.parameter_defaults) for c in flow.schedule.clocks]
-        ):
-            raise ValueError("Can not schedule a flow that has required parameters.")
-
     # set up task detail info
     task_lookup = {t.slug: t for t in flow.tasks}
     tasks_with_upstreams = {e.downstream_task for e in flow.edges}
@@ -229,7 +218,7 @@ async def create_flow(
         flow_group_id=flow_group_id,
         description=description,
         schedule=serialized_flow.get("schedule"),
-        is_schedule_active=set_schedule_active,
+        is_schedule_active=False,
         tasks=[
             models.Task(
                 id=t.id,
@@ -264,7 +253,7 @@ async def create_flow(
 
     # schedule runs
     if set_schedule_active:
-        await api.flows.schedule_flow_runs(flow_id=flow_id)
+        await api.flows.set_schedule_active(flow_id=flow_id)
 
     return flow_id
 
@@ -396,6 +385,30 @@ async def set_schedule_active(flow_id: str) -> bool:
     """
     if flow_id is None:
         raise ValueError("Invalid flow id.")
+
+    flow = await models.Flow.where(id=flow_id).first(
+        {
+            "schedule": True,
+            "parameters": True,
+            "flow_group": {"schedule": True, "default_parameters": True},
+        }
+    )
+
+    if not flow:
+        return False
+
+    # logic for determining if it's appropriate to turn on the schedule for this flow
+    required_parameters = {p.get("name") for p in flow.parameters if p.get("required")}
+    if flow.schedule is not None and required_parameters:
+        required_names = required_parameters.difference(
+            flow.flow_group.default_parameters or {}
+        )
+        clock_params = [
+            set(c.get("parameter_defaults", {}).keys())
+            for c in flow.schedule.get("clocks", [])
+        ]
+        if not all([required_names <= c for c in clock_params]):
+            raise ValueError("Can not schedule a flow that has required parameters.")
 
     result = await models.Flow.where(id=flow_id).update(
         set={"is_schedule_active": True}

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -751,6 +751,17 @@ class TestSetScheduleActive:
         with pytest.raises(ValueError, match="Invalid flow id"):
             await api.flows.set_schedule_active(flow_id=None)
 
+    async def test_set_schedule_active_with_required_parameters(self, project_id):
+        flow = prefect.Flow(
+            name="test",
+            tasks=[prefect.Parameter("p", required=True)]
+        )
+        flow_id = await api.flows.create_flow(
+            serialized_flow=flow.serialize(), project_id=project_id
+        )
+        with pytest.raises(ValueError):
+            await api.flows.set_schedule_active(flow_id=flow_id)
+
     async def test_set_schedule_active_with_bad_id(self):
         assert not await api.flows.set_schedule_active(flow_id=str(uuid.uuid4()))
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR consolidates all logic for setting a flow schedule to active in the 🥁 `set_schedule_active` mutation.  This will make it much simpler to maintain and test moving forward.


## Changes
<!-- What does this PR change? -->
The following behavioral changes will occur as a consequence of this PR:
- closes #86 (error returned but schedule was still set to active)
- allows for default parameters to come from clocks, flow group defaults, or both! (this is new functionality)
- allows for flows with required parameters and schedules to still be registered, but they will not have their schedule set to active (this is drastically different behavior from the current situation where an error is raised prior to creation)



## Importance
<!-- Why is this PR important? -->
Fixes a few outstanding bugs + cleans up what I think was tech debt



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
