### PR TITLE
Use prefect.models in favor of database.models

### DIFF
--- a/changes/pr89.yml
+++ b/changes/pr89.yml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix agent API calling `prefect.api.models` instead of `prefect.models` - [#89](https://github.com/PrefectHQ/server/pull/89)"
+
+enhancement:
+  - "Replace calls to `prefect_server.database.models` with `prefect.models` - [#89](https://github.com/PrefectHQ/server/pull/89)"

--- a/src/prefect_server/api/agents.py
+++ b/src/prefect_server/api/agents.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pendulum
 
-from prefect_server.database import models
+from prefect import models
 from prefect_server.utilities import context
 from prefect.utilities.plugins import register_api
 

--- a/src/prefect_server/api/agents.py
+++ b/src/prefect_server/api/agents.py
@@ -4,7 +4,6 @@ import pendulum
 
 from prefect_server.database import models
 from prefect_server.utilities import context
-from prefect import api
 from prefect.utilities.plugins import register_api
 
 
@@ -37,7 +36,7 @@ async def register_agent(
             tenant_id = await models.Tenant.where({"id": {"_eq": None}}).first().id
         except:
             raise ValueError("No tenant found.")
-    return await api.models.Agent(
+    return await models.Agent(
         tenant_id=tenant_id,
         agent_config_id=agent_config_id,
         labels=labels or [],
@@ -60,7 +59,7 @@ async def update_agent_last_queried(agent_id: str) -> bool:
     """
     if agent_id is None:
         raise ValueError("Must supply an agent ID to update.")
-    result = await api.models.Agent.where(id=agent_id).update(
+    result = await models.Agent.where(id=agent_id).update(
         set={"last_queried": pendulum.now("utc")}
     )
     return bool(result.affected_rows)  # type: ignore
@@ -79,7 +78,7 @@ async def delete_agent(agent_id: str) -> bool:
     """
     if agent_id is None:
         raise ValueError("Must supply an agent ID to delete.")
-    result = await api.models.Agent.where(id=agent_id).delete()
+    result = await models.Agent.where(id=agent_id).delete()
     return bool(result.affected_rows)  # type: ignore
 
 
@@ -100,7 +99,7 @@ async def create_agent_config(
     Returns:
         - str: the agent config id
     """
-    return await api.models.AgentConfig(
+    return await models.AgentConfig(
         tenant_id=tenant_id, name=name, settings=settings
     ).insert()
 
@@ -118,7 +117,7 @@ async def delete_agent_config(agent_config_id: str) -> bool:
     """
     if agent_config_id is None:
         raise ValueError("Must supply an agent ID to delete.")
-    result = await api.models.AgentConfig.where(id=agent_config_id).delete()
+    result = await models.AgentConfig.where(id=agent_config_id).delete()
     return bool(result.affected_rows)  # type: ignore
 
 
@@ -146,5 +145,5 @@ async def update_agent_config(
     if settings is not None:
         update["settings"] = settings
 
-    result = await api.models.AgentConfig.where(id=agent_config_id).update(set=update)
+    result = await models.AgentConfig.where(id=agent_config_id).update(set=update)
     return bool(result.affected_rows)  # type: ignore

--- a/src/prefect_server/api/cloud_hooks.py
+++ b/src/prefect_server/api/cloud_hooks.py
@@ -8,9 +8,8 @@ from box import Box
 from pydantic import BaseModel
 
 import prefect
-from prefect import api
+from prefect import api, models
 from prefect_server import config as server_config
-from prefect_server.database import models
 from prefect_server.utilities import logging, names, events
 from prefect.utilities.plugins import register_api
 

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -2,8 +2,7 @@ from typing import List
 
 from prefect.serialization.schedule import ClockSchema
 
-from prefect import api
-from prefect_server.database import models
+from prefect import api, models
 from prefect.utilities.plugins import register_api
 
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -8,9 +8,8 @@ from pydantic import BaseModel, Field, validator
 
 from prefect.serialization.schedule import ScheduleSchema
 from prefect.utilities.graphql import with_args
-from prefect import api
+from prefect import api, models
 from prefect_server import config
-from prefect_server.database import models
 from prefect_server.utilities import logging
 from prefect.utilities.plugins import register_api
 

--- a/src/prefect_server/api/logs.py
+++ b/src/prefect_server/api/logs.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 import pendulum
 import pydantic
 
-from prefect_server.database import models
+from prefect import models
 from prefect.utilities.plugins import register_api
 
 

--- a/src/prefect_server/api/messages.py
+++ b/src/prefect_server/api/messages.py
@@ -1,4 +1,4 @@
-from prefect_server.database import models
+from prefect import models
 from prefect.utilities.plugins import register_api
 
 PREFECT_MESSAGE_TYPES = {"CLOUD_HOOK", "REQUIRES_APPROVAL"}

--- a/src/prefect_server/api/projects.py
+++ b/src/prefect_server/api/projects.py
@@ -1,4 +1,4 @@
-from prefect_server.database import models
+from prefect import models
 from prefect.utilities.plugins import register_api
 
 

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -6,9 +6,8 @@ import pendulum
 import prefect
 from prefect.engine.state import Pending, Queued, Scheduled
 from prefect.utilities.graphql import EnumValue
-from prefect import api
+from prefect import api, models
 from prefect_server import config
-from prefect_server.database import models
 from prefect_server.utilities import exceptions, names
 from prefect.utilities.plugins import register_api
 

--- a/src/prefect_server/api/states.py
+++ b/src/prefect_server/api/states.py
@@ -9,8 +9,7 @@ from box import Box
 
 import prefect
 from prefect.engine.state import Cancelled, Cancelling, State
-from prefect import api
-from prefect_server.database import models
+from prefect import api, models
 from prefect_server.utilities import events
 from prefect_server.utilities.logging import get_logger
 from prefect.utilities.plugins import register_api

--- a/src/prefect_server/api/tenants.py
+++ b/src/prefect_server/api/tenants.py
@@ -1,6 +1,6 @@
 import slugify
 
-from prefect_server.database import models
+from prefect import models
 from prefect.utilities.plugins import register_api
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary

Attempting to access the models via
```python
from prefect import api

api.models.Agent
```

Raises a `box.BoxKeyError: "'Box' object has no attribute 'models'"` and instead it needs to be `from prefect import models`.

## Changes
Updates all API files that called `prefect_server.database.models` in favor of `prefect.models`



## Importance
Code reuse and ensuring smooth repo-specific functionality



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
