### PR TITLE
Match agents to existing entries during registration

### DIFF
--- a/changes/pr.yaml
+++ b/changes/pr.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix `name` field in `delete_agent` GraphQL resolver - [#95](https://github.com/PrefectHQ/server/pull/95)"
+
+enhancement:
+  - "Registering agents will now retrieve IDs from matching entries in order to prevent duplication - [#95](https://github.com/PrefectHQ/server/pull/95)"

--- a/src/prefect_server/api/agents.py
+++ b/src/prefect_server/api/agents.py
@@ -36,10 +36,29 @@ async def register_agent(
             tenant_id = await models.Tenant.where({"id": {"_eq": None}}).first().id
         except:
             raise ValueError("No tenant found.")
+
+    # Check for existing agents with these kwargs
+    agent = await models.Agent.where(
+        {
+            "_and": [
+                {"tenant_id": {"_eq": tenant_id}},
+                {"name": {"_eq": name}},
+                {"type": {"_eq": type}},
+                {"core_version": {"_eq": core_version}},
+                {"labels": {"_eq": sorted(labels or [])}},
+            ]
+        }
+    ).first()
+
+    # Return existing agent ID
+    if agent:
+        return agent.id
+
+    # Insert new agent
     return await models.Agent(
         tenant_id=tenant_id,
         agent_config_id=agent_config_id,
-        labels=labels or [],
+        labels=sorted(labels or []),
         name=name,
         type=type,
         core_version=core_version,

--- a/src/prefect_server/graphql/agents.py
+++ b/src/prefect_server/graphql/agents.py
@@ -33,7 +33,7 @@ async def resolve_create_agent_config(
     return {
         "id": await api.agents.create_agent_config(
             tenant_id=input["tenant_id"],
-            agent=input.get("name"),
+            name=input.get("name"),
             settings=input.get("settings"),
         )
     }

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -74,6 +74,49 @@ class TestCreateAgent:
         ).count()
         assert agent_count == 2
 
+    async def test_register_multiple_agents_label_order(self, tenant_id):
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo", "bar", "chris"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["chris", "bar", "foo"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["bar", "chris", "foo"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo", "chris", "bar"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["bar", "foo", "chris"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["chris", "foo", "bar"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
 
 class TestUpdateAgentLastQueried:
     async def test_update_agent_last_queried(self, agent_id):

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -1,0 +1,108 @@
+import pendulum
+import pytest
+
+from prefect import api, models
+from prefect_server import config
+
+
+class TestCreateAgent:
+    async def test_register_agent(self, tenant_id):
+        # create an agent
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo", "bar"],
+        )
+        agent = await models.Agent.where(id=agent_id).first(
+            {"id", "tenant_id", "labels"}
+        )
+        assert agent.id == agent_id
+        assert agent.tenant_id == tenant_id
+        assert set(agent.labels) == set(["bar", "foo"])
+
+    @pytest.mark.parametrize("labels", [[], None])
+    async def test_register_agent_with_empty_labels(self, tenant_id, labels):
+        # create an agent
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=labels,
+        )
+        agent = await models.Agent.where(id=agent_id).first(
+            {"id", "tenant_id", "labels"}
+        )
+        assert agent.id == agent_id
+        assert agent.tenant_id == tenant_id
+        assert agent.labels == []
+
+    async def test_register_agent_with_optional_arguments(self, tenant_id):
+        labels = ["foo", "bar"]
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id, name="MyNewAgent", type="NewAgent", labels=labels
+        )
+        agent = await models.Agent.where(id=agent_id).first(
+            {"id", "tenant_id", "labels", "name", "type"}
+        )
+        assert agent.id == agent_id
+        assert agent.tenant_id == tenant_id
+        assert agent.name == "MyNewAgent"
+        assert agent.type == "NewAgent"
+        assert set(agent.labels) == set(labels)
+
+    async def test_register_multiple_agents(self, tenant_id):
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo", "bar"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo", "bar"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_id = await api.agents.register_agent(
+            tenant_id=tenant_id,
+            labels=["foo2", "bar2"],
+        )
+        agent_count = await models.Agent.where(id=agent_id).count()
+        assert agent_count == 1
+
+        agent_count = await models.Agent.where(
+            {"tenant_id": {"_eq": tenant_id}}
+        ).count()
+        assert agent_count == 2
+
+
+class TestUpdateAgentLastQueried:
+    async def test_update_agent_last_queried(self, agent_id):
+        start_time = pendulum.now("utc")
+
+        # Update last queried
+        assert await api.agents.update_agent_last_queried(agent_id=agent_id) is True
+
+        agent = await models.Agent.where(id=agent_id).first({"last_queried"})
+
+        # Check last queried time
+        assert start_time <= agent.last_queried <= pendulum.now("utc")
+
+    async def test_update_agent_with_none_id_raises_error(self, agent_id):
+        with pytest.raises(ValueError, match="Must supply an agent ID to update."):
+            await api.agents.update_agent_last_queried(agent_id=None)
+
+
+class TestDeleteAgent:
+    async def test_delete_agent(self, agent_id):
+        # delete the agent
+        await api.agents.delete_agent(agent_id=agent_id)
+        # confirm the agent was deleted
+        agent = await models.Agent.where(id=agent_id).first()
+        assert agent is None
+
+    async def test_delete_agent_with_none_id_raises_error(self, agent_id):
+        # confirm the error is raised as expected
+        with pytest.raises(ValueError, match="Must supply an agent ID to delete."):
+            await api.agents.delete_agent(agent_id=None)
+        # confirm the agent still exists
+        assert await models.Agent.where(id=agent_id).first() is not None

--- a/tests/fixtures/database_fixtures.py
+++ b/tests/fixtures/database_fixtures.py
@@ -25,6 +25,11 @@ async def tenant_id():
 
 
 @pytest.fixture
+async def agent_id(tenant_id):
+    return await api.agents.register_agent(tenant_id=tenant_id, labels=["foo", "bar"])
+
+
+@pytest.fixture
 async def project_id(tenant_id):
     project_id = await api.projects.create_project(
         tenant_id=tenant_id, name="Test Project"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
If an agent is constantly restarting this could lead to a large amount of data being created because each restart previously created a new instance of an agent row in the db. This PR relieves that by matching agents against tenant_id, name, type, core_version, and labels. If an agent is already found to have been created with that configuration the ID of that agent is returned from registration and a new entry is not created.

Example: Due to auto deploys of some infrastructure this is a common occurrence where 18 of these agents do not matter any more.
![image](https://user-images.githubusercontent.com/40716964/94065129-b161ae00-fdb8-11ea-87e0-12bbec42abf4.png)

We still have plans for identifying distressed agents but that is going to come out through the use of the agent config concept!

## Changes
Fixes the delete_agent graphql resolver
Performs an "upsert" of agents when registering



## Importance
From a usability perspective this is key because there is too much potential to create a large amount of agent entries thus leading to issues.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
