### PR TITLE
Scheduler labels

### DIFF
--- a/changes/pr109.yaml
+++ b/changes/pr109.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "Allow for scheduling changing labels on a per-flow run basis - [#109](https://github.com/PrefectHQ/server/pull/109)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -29,6 +29,7 @@ class Model(BaseModel):
 
 class ClockSchema(Model):
     parameter_defaults: Dict = Field(default_factory=dict)
+    labels: List[str] = Field(default_factory=list)
 
 
 class ScheduleSchema(Model):
@@ -548,6 +549,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             flow_id=flow_id,
             scheduled_start_time=event.start_time,
             parameters=event.parameter_defaults,
+            labels=event.labels or None,
             idempotency_key=f"auto-scheduled:{event.start_time.in_tz('UTC')}",
         )
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -29,7 +29,7 @@ class Model(BaseModel):
 
 class ClockSchema(Model):
     parameter_defaults: Dict = Field(default_factory=dict)
-    labels: List[str] = Field(default_factory=list)
+    labels: List[str] = Field(default=None)
 
 
 class ScheduleSchema(Model):
@@ -549,7 +549,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             flow_id=flow_id,
             scheduled_start_time=event.start_time,
             parameters=event.parameter_defaults,
-            labels=event.labels or None,
+            labels=event.labels,
             idempotency_key=f"auto-scheduled:{event.start_time.in_tz('UTC')}",
         )
 

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1070,11 +1070,12 @@ class TestScheduledRunAttributes:
         assert all([fr.labels == ["a", "b"] for fr in flow_runs[::2]])
         assert all([fr.labels == ["c", "d"] for fr in flow_runs[1::2]])
 
-    async def test_schedule_does_not_overwrite_flow_labels(self, project_id):
+    @pytest.mark.parametrize("labels", [[], ["a", "b"]])
+    async def test_schedule_does_not_overwrite_flow_labels(self, project_id, labels):
         clock1 = prefect.schedules.clocks.IntervalClock(
             start_date=pendulum.now("UTC").add(minutes=1),
             interval=datetime.timedelta(minutes=2),
-            labels=["a", "b"],
+            labels=labels,
         )
         clock2 = prefect.schedules.clocks.IntervalClock(
             start_date=pendulum.now("UTC"),
@@ -1098,7 +1099,7 @@ class TestScheduledRunAttributes:
             order_by={"scheduled_start_time": EnumValue("asc")},
         )
 
-        assert all([fr.labels == ["a", "b"] for fr in flow_runs[::2]])
+        assert all([fr.labels == labels for fr in flow_runs[::2]])
         assert all([fr.labels == ["bar", "foo"] for fr in flow_runs[1::2]])
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR uses the enhancement made in https://github.com/PrefectHQ/prefect/pull/3483 to actually create flow runs with the appropriate labels provided by each individual Clock.  In particular, this will:
- allow users to schedule a single flow to run in multiple places simultaneously
- allow users to schedule a single flow to run in multiple places across time

## Importance
<!-- Why is this PR important? -->
Big new orchestration feature!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
