### PR TITLE
Properly check for agent id before updating flow run agent

### DIFF
--- a/changes/issue114.yaml
+++ b/changes/issue114.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Check for existence of agent before updating flow run agent - [#114](https://github.com/PrefectHQ/server/issues/114)"

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -395,7 +395,7 @@ async def delete_flow_run(flow_run_id: str) -> bool:
 
 
 @register_api("runs.update_flow_run_agent")
-async def update_flow_run_agent(flow_run_id: str, agent_id: str) -> None:
+async def update_flow_run_agent(flow_run_id: str, agent_id: str) -> bool:
     """
     Updates the agent instance of a flow run
 
@@ -406,6 +406,11 @@ async def update_flow_run_agent(flow_run_id: str, agent_id: str) -> None:
     Returns:
         bool: if the update was successful
     """
+
+    agent = await models.Agent.where(id=agent_id).first()
+    if not agent:
+        return False
+
     result = await models.FlowRun.where(id=flow_run_id).update(
         set={"agent_id": agent_id}
     )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Previously when attempting to update a flow run's agent id with an id that didn't exist it would raise a foreign key violation. An existing agent id should not be a determining factor on a flow run being submitted. 



## Importance
Closes #114 




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
