### PR TITLE
Expose database upgrade errors during infra start

### DIFF
--- a/changes/pr117.yaml
+++ b/changes/pr117.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Expose database upgrade errors during infrastructure start  - [#117](https://github.com/PrefectHQ/server/pull/117)"

--- a/src/prefect_server/cli/dev.py
+++ b/src/prefect_server/cli/dev.py
@@ -108,11 +108,20 @@ def infrastructure(tag, skip_pull, skip_upgrade):
                     click.secho("Database upgraded.", fg="green")
                     break
                 # trap error during the SELECT 1
-                except sqlalchemy.exc.OperationalError:
-                    click.secho(
-                        "Database not ready yet. Waiting 1 second to retry upgrade."
-                    )
-                    time.sleep(1)
+                except sqlalchemy.exc.OperationalError as exc:
+                    if "Connection refused" in str(exc):
+                        click.echo(
+                            "Database not ready yet. Waiting 1 second to retry upgrade."
+                        )
+                        time.sleep(1)
+                    else:
+                        click.secho(
+                            "Database upgrade encountered fatal error:\n",
+                            fg="red",
+                            bold=True,
+                        )
+                        click.secho(str(exc) + "\n", fg="red")
+                        raise
 
         click.echo(ascii_welcome())
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

An error during database upgrade is hidden with a message "Database is not ready..."

## Changes

- Only displays that the database is not ready when the exception is a refused connection
- Other exceptions are displayed and reraised

Example output
```
prefect-3.7 ❯ prefect-server dev infrastructure
Pulling postgres ... done
Pulling hasura   ... done
Database upgrade encountered fatal error:

(psycopg2.OperationalError) FATAL:  role "prefect" does not exist

(Background on this error at: http://sqlalche.me/e/13/e3q8)

Exception caught; killing services (press ctrl-C to force)

... full traceback
```

## Importance
<!-- Why is this PR important? -->

Silencing exceptions during database setup makes it challenging to troubleshoot

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
