### PR TITLE
Add bulk flow run deletion mutation

### DIFF
--- a/changes/pr118.yaml
+++ b/changes/pr118.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add api route for bulk deletion of flow runs - [#116](https://github.com/PrefectHQ/server/pull/116)"

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -400,7 +400,7 @@ async def delete_flow_runs(flow_run_ids: List[str]) -> int:
     Deletes a set of flow runs
 
     Args:
-        - flow_run_id (str): the flow run to delete
+        - flow_run_ids (List[str]): the list of flow runs to delete
 
     Returns:
         - int: The number of affected rows

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -394,6 +394,21 @@ async def delete_flow_run(flow_run_id: str) -> bool:
     return bool(result.affected_rows)  # type: ignore
 
 
+@register_api("runs.delete_flow_runs")
+async def delete_flow_runs(flow_run_ids: List[str]) -> int:
+    """
+    Deletes a set of flow runs
+
+    Args:
+        - flow_run_id (str): the flow run to delete
+
+    Returns:
+        - int: The number of affected rows
+    """
+    result = await models.FlowRun.where({"id": {"_in": flow_run_ids}}).delete()
+    return result.affected_rows  # type: ignore
+
+
 @register_api("runs.update_flow_run_agent")
 async def update_flow_run_agent(flow_run_id: str, agent_id: str) -> bool:
     """

--- a/src/prefect_server/graphql/runs.py
+++ b/src/prefect_server/graphql/runs.py
@@ -150,6 +150,17 @@ async def resolve_delete_flow_run(
     return {"success": await api.runs.delete_flow_run(flow_run_id=input["flow_run_id"])}
 
 
+@mutation.field("delete_flow_runs")
+async def resolve_delete_flow_runs(
+    obj: Any, info: GraphQLResolveInfo, input: dict
+) -> dict:
+    return {
+        "affected_rows": await api.runs.delete_flow_runs(
+            flow_run_ids=input["flow_run_ids"]
+        )
+    }
+
+
 @mutation.field("update_flow_run_heartbeat")
 async def resolve_update_flow_run_heartbeat(
     obj: Any, info: GraphQLResolveInfo, input: dict

--- a/src/prefect_server/graphql/schema/runs.graphql
+++ b/src/prefect_server/graphql/schema/runs.graphql
@@ -44,6 +44,9 @@ extend type Mutation {
   "Delete a flow run."
   delete_flow_run(input: delete_flow_run_input!): success_payload
 
+  "Delete a group of flow runs."
+  delete_flow_runs(input: delete_flow_runs_input!): deleted_count_payload
+
   get_runs_in_queue(input: get_runs_in_queue_input!): runs_in_queue_payload
 
 }
@@ -119,6 +122,10 @@ input delete_flow_run_input {
   flow_run_id: UUID!
 }
 
+input delete_flow_runs_input {
+  flow_run_ids: [UUID!]
+}
+
 type flow_run_id_payload {
   id: UUID
 }
@@ -139,4 +146,8 @@ type mapped_children_payload {
   min_start_time: DateTime
   max_end_time: DateTime
   state_counts: JSON
+}
+
+type deleted_count_payload {
+  affected_rows: Int
 }

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -799,10 +799,12 @@ class TestDeleteFlowRuns:
         assert list(flow_runs) == []
 
     async def test_delete_flow_runs_allows_bad_id(self, flow_run_id):
-        result = await api.runs.delete_flow_runs(
-            flow_run_ids=[flow_run_id, str(uuid.uuid4())]
-        )
+        flow_run_ids = [flow_run_id, str(uuid.uuid4())]
+        result = await api.runs.delete_flow_runs(flow_run_ids=flow_run_ids)
+        flow_runs = await models.FlowRun.where({"id": {"_in": flow_run_ids}}).get()
+
         assert result == 1
+        assert not flow_runs  # Ensure the real run was deleted still
 
     async def test_delete_flow_runs_allows_all_bad_ids(self):
         result = await api.runs.delete_flow_runs(flow_run_ids=[str(uuid.uuid4())])

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -786,6 +786,28 @@ class TestDeleteFlowRuns:
         with pytest.raises(ValueError, match="Invalid flow run ID"):
             await api.runs.delete_flow_run(flow_run_id=bad_value)
 
+    async def test_delete_flow_runs(self, flow_id):
+        flow_run_ids = [
+            await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=i))
+            for i in range(2)
+        ]
+
+        result = await api.runs.delete_flow_runs(flow_run_ids=flow_run_ids)
+        flow_runs = await models.FlowRun.where({"id": {"_in": flow_run_ids}}).get()
+
+        assert result == 2
+        assert list(flow_runs) == []
+
+    async def test_delete_flow_runs_allows_bad_id(self, flow_run_id):
+        result = await api.runs.delete_flow_runs(
+            flow_run_ids=[flow_run_id, str(uuid.uuid4())]
+        )
+        assert result == 1
+
+    async def test_delete_flow_runs_allows_all_bad_ids(self):
+        result = await api.runs.delete_flow_runs(flow_run_ids=[str(uuid.uuid4())])
+        assert result == 0
+
 
 class TestGetRunsInQueue:
     async def test_get_flow_run_in_queue(self, flow_run_id, tenant_id):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds `delete_flow_runs` mutation which allows deletion of a list of flow run ids instead of calling `delete_flow_run`repeatedly

## Importance
<!-- Why is this PR important? -->

Closes #62 

This is also a good opportunity for me to familiarize myself with the graphql routes, if this is not a feature we want to support then we can just close this ticket.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
