### PR TITLE
Bound urllib3 to prevent dependency conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,16 @@ install_requires = [
     "graphql-core < 3.1",
     "httpx >= 0.13.0, < 0.14.0",
     "json_log_formatter >= 0.3.0, < 0.4.0",
+    "packaging >= 20.0, < 20.4",
     "psycopg2-binary >= 2.7, < 3.0",
     # pin below 1.6 pending https://github.com/samuelcolvin/pydantic/issues/1710
     "pydantic >= 1.5, < 1.6",
     "python-slugify >= 1.2,< 5.0",
+    "pyyaml >= 3.13, < 6.0",
     "starlette >= 0.13, < 0.14",
     "toml >= 0.9.0, < 0.11",
     "uvicorn >= 0.11.4, < 0.12",
-    "pyyaml >= 3.13, < 6.0",
-    "packaging >= 20.0, < 20.4",
+    "urllib3 < 1.26",
 ]
 
 dev_requires = [

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ install_requires = [
     "pyyaml >= 3.13, < 6.0",
     "starlette >= 0.13, < 0.14",
     "toml >= 0.9.0, < 0.11",
-    "uvicorn >= 0.11.4, < 0.12",
     "urllib3 < 1.26",
+    "uvicorn >= 0.11.4, < 0.12",
 ]
 
 dev_requires = [


### PR DESCRIPTION
Starting the server is raising the following dependency error. Pinning urllib3 until this conflict is fixed with requests

```
graphql_1   | Traceback (most recent call last):
graphql_1   |   File "/usr/local/bin/prefect-server", line 15, in <module>
graphql_1   |     from pkg_resources import load_entry_point
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3238, in <module>
graphql_1   |     @_call_aside
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3222, in _call_aside
graphql_1   |     f(*args, **kwargs)
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3251, in _initialize_master_working_set
graphql_1   |     working_set = WorkingSet._build_master()
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 569, in _build_master
graphql_1   |     return cls._build_from_requirements(__requires__)
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 582, in _build_from_requirements
graphql_1   |     dists = ws.resolve(reqs, Environment())
graphql_1   |   File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 775, in resolve
graphql_1   |     raise VersionConflict(dist, req).with_context(dependent_req)
graphql_1   | pkg_resources.ContextualVersionConflict: (urllib3 1.26.0 (/usr/local/lib/python3.7/site-packages), Requirement.parse('urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1'), {'requests'})
```