### PR TITLE
Fix dev infrastructure spinup failure

### DIFF
--- a/changes/pr130.yaml
+++ b/changes/pr130.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "prefect-server dev infrastructure would sometimes fail to start with 'connection closed' - [#130](https://github.com/PrefectHQ/server/pull/130)"

--- a/src/prefect_server/cli/dev.py
+++ b/src/prefect_server/cli/dev.py
@@ -109,7 +109,7 @@ def infrastructure(tag, skip_pull, skip_upgrade):
                     break
                 # trap error during the SELECT 1
                 except sqlalchemy.exc.OperationalError as exc:
-                    if "Connection refused" in str(exc):
+                    if "Connection refused" in str(exc) or "closed the connection" in str(exc):
                         click.echo(
                             "Database not ready yet. Waiting 1 second to retry upgrade."
                         )

--- a/src/prefect_server/cli/dev.py
+++ b/src/prefect_server/cli/dev.py
@@ -109,7 +109,9 @@ def infrastructure(tag, skip_pull, skip_upgrade):
                     break
                 # trap error during the SELECT 1
                 except sqlalchemy.exc.OperationalError as exc:
-                    if "Connection refused" in str(exc) or "closed the connection" in str(exc):
+                    if "Connection refused" in str(
+                        exc
+                    ) or "closed the connection" in str(exc):
                         click.echo(
                             "Database not ready yet. Waiting 1 second to retry upgrade."
                         )

--- a/src/prefect_server/cli/dev.py
+++ b/src/prefect_server/cli/dev.py
@@ -109,9 +109,8 @@ def infrastructure(tag, skip_pull, skip_upgrade):
                     break
                 # trap error during the SELECT 1
                 except sqlalchemy.exc.OperationalError as exc:
-                    if "Connection refused" in str(
-                        exc
-                    ) or "closed the connection" in str(exc):
+                    msg = str(exc)
+                    if "Connection refused" in msg or "closed the connection" in msg:
                         click.echo(
                             "Database not ready yet. Waiting 1 second to retry upgrade."
                         )


### PR DESCRIPTION


<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`prefect-server dev infrastructure` fails because the database isn't ready, the check on the exception waiting for readiness was made too narrow.

## Changes

- Adds an additional case to the exception catch that waits for the database to be ready

Was failing with:
```
Database upgrade encountered fatal error:

(psycopg2.OperationalError) server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

(Background on this error at: http://sqlalche.me/e/13/e3q8)

Exception caught; killing services (press ctrl-C to force)
```

## Importance
<!-- Why is this PR important? -->

- Spinning up dev infrastructure was broken


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [ ] adds a change file in the `changes/` directory (if appropriate)
