### PR TITLE
Set PREFECT_SERVER_VERSION during versioned docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ workflows:
           docker-username: DOCKER_HUB_USER
           image: 'prefecthq/apollo'
           path: 'services/apollo'
-          extra_build_args: '--build-arg PREFECT_VERSION=master --build-arg RELEASE_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
+          extra_build_args: '--build-arg PREFECT_VERSION=master --build-arg PREFECT_SERVER_VERSION=$CIRCLE_TAG --build-arg RELEASE_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
           tag: $CIRCLE_TAG,latest
           filters:
             branches:
@@ -228,7 +228,7 @@ workflows:
           docker-username: DOCKER_HUB_USER
           image: 'prefecthq/server'
           path: '.'
-          extra_build_args: '--build-arg PREFECT_VERSION=master --build-arg RELEASE_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
+          extra_build_args: '--build-arg PREFECT_VERSION=master --build-arg PREFECT_SERVER_VERSION=$CIRCLE_TAG --build-arg RELEASE_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
           tag: $CIRCLE_TAG,latest
           filters:
             branches:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

`PREFECT_SERVER_VERSION` is referenced within the API and Dockerfile but never differs from `master` as written, to fix:

- Sets `PREFECT_SERVER_VERSION` to the git tag for tagged CI image builds

## Importance
<!-- Why is this PR important? -->

The server version should be set correctly for tagged images

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [ ] adds a change file in the `changes/` directory (if appropriate)
