### PR TITLE
Fix helm chart when using existing postgres instance

### DIFF
--- a/changes/pr132.yaml
+++ b/changes/pr132.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix helm chart when using existing postgres instance - [#132](https://github.com/PrefectHQ/server/pull/132)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/helm/prefect-server/Chart.yaml
+++ b/helm/prefect-server/Chart.yaml
@@ -8,4 +8,4 @@ dependencies:
 - name: postgresql
   version: "~9.3.2"
   repository: https://charts.bitnami.com/bitnami
-  condition: postgres.useSubChart
+  condition: postgresql.useSubChart

--- a/helm/prefect-server/templates/_helpers.tpl
+++ b/helm/prefect-server/templates/_helpers.tpl
@@ -124,8 +124,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     an existing secret is not set.
 */}}
 {{- define "prefect-server.postgres-secret-name" -}}
-{{- if .Values.postgresql.secretName -}}
-  {{- .Values.postgresql.secretName -}}
+{{- if .Values.postgresql.existingSecret -}}
+  {{- .Values.postgresql.existingSecret -}}
 {{- else -}}
   {{- printf "%s-%s" .Release.Name "postgresql" -}}
 {{- end -}}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

With the merge of #123 the repo contains helm chart for deploying in Kubernetes. However, for deploying with an existing postgres instance, there were some errors.


## Importance
<!-- Why is this PR important? -->

Completes #123 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] ~adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
