### PR TITLE
Fix scheduling duplicate runs with expired idempotency keys

### DIFF
--- a/changes/pr134.yaml
+++ b/changes/pr134.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix scheduling duplicate runs due to expired idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"

--- a/changes/pr134.yaml
+++ b/changes/pr134.yaml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Remove global 24 hour expiry on flow run idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"
+  - "Remove global 24 hour expiration on flow run idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"
 
 fix:
   - "Fix scheduling duplicate runs due to expired idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"

--- a/changes/pr134.yaml
+++ b/changes/pr134.yaml
@@ -1,2 +1,5 @@
+enhancement:
+  - "Remove global 24 hour expiry on flow run idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"
+
 fix:
   - "Fix scheduling duplicate runs due to expired idempotency keys - [#134](https://github.com/PrefectHQ/server/pull/134)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -579,21 +579,6 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
     # schedule every event with an idempotent flow run
     for event in flow_schedule.next(n=max_runs, return_events=True):
 
-        # TODO: This has potential to miss scheduling runs that all need to be scheduled at the same time
-        # in the case of a restart while only a portion of that time's runs have been scheduled. There
-        # needs to be some external tracker or query here that looks to see if any of the runs have
-        # already been scheduled.
-        #
-        # For example, say there is a flow with a schedule that has 10 different clocks, each with a
-        # different parameter. This loop is running through to schedule the next 10 runs and half way
-        # through the service restartes (due to some external pressure). Then when it loads back up
-        # it will not schedule the remaining half of the runs because of the last_scheduled_run check
-        # below. Therefore something needs to check if all of the runs for that particular time had
-        # actually been scheduled.
-
-        # if this run was already scheduled, continue
-        if last_scheduled_run and event.start_time <= last_scheduled_run:
-            continue
         # if the event has parameter defaults or labels, we do allow for
         # same-time scheduling
         if event.parameter_defaults or event.labels is not None:
@@ -604,6 +589,9 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             idempotency_key = (
                 f"auto-scheduled:{event.start_time.in_tz('UTC')}:{md5.hexdigest()}"
             )
+        # if this run was already scheduled, continue
+        elif last_scheduled_run and event.start_time <= last_scheduled_run:
+            continue
         else:
             idempotency_key = f"auto-scheduled:{event.start_time.in_tz('UTC')}"
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -596,7 +596,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             continue
         # if the event has parameter defaults or labels, we do allow for
         # same-time scheduling
-        elif event.parameter_defaults or event.labels is not None:
+        if event.parameter_defaults or event.labels is not None:
             md5 = hashlib.md5()
             param_string = str(sorted(json.dumps(event.parameter_defaults)))
             label_string = str(sorted(json.dumps(event.labels)))

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -50,7 +50,6 @@ async def create_flow_run(
 
         where = {
             "idempotency_key": {"_eq": idempotency_key},
-            "created": {"_gt": str(pendulum.now().subtract(days=1))},
         }
         if flow_id is not None:
             where.update({"flow_id": {"_eq": flow_id}})

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1308,6 +1308,54 @@ class TestScheduledRunAttributes:
 
         assert len(set([fr.scheduled_start_time for fr in flow_runs])) == 5
 
+    @pytest.mark.parametrize(
+        "attrs",
+        [
+            [
+                dict(parameter_defaults=dict(x="a")),
+                dict(parameter_defaults=dict(x="b")),
+            ],
+            [dict(parameter_defaults=dict(x="a")), dict(parameter_defaults=None)],
+            [dict(parameter_defaults=dict(x="a")), dict(labels=["b"])],
+            [dict(labels=["c", "d"]), dict(labels=["c"])],
+            [dict(labels=None), dict(labels=["ef"])],
+            [
+                dict(labels=None),
+                dict(labels=[]),
+            ],  # the scheduler should distinguish between none vs. empty
+        ],
+    )
+    async def test_same_time_different_parameters_does_not_schedule_duplicates(
+        self, project_id, attrs
+    ):
+        now = pendulum.now("UTC")
+        clock1 = prefect.schedules.clocks.IntervalClock(
+            start_date=now.add(minutes=1),
+            interval=datetime.timedelta(minutes=2),
+            **attrs[0],
+        )
+        clock2 = prefect.schedules.clocks.IntervalClock(
+            start_date=now.add(minutes=1),
+            interval=datetime.timedelta(minutes=2),
+            **attrs[1],
+        )
+
+        flow = prefect.Flow(
+            name="Test Scheduled Flow",
+            schedule=prefect.schedules.Schedule(clocks=[clock1, clock2]),
+        )
+        flow.add_task(prefect.Parameter("x", default=1))
+        flow_id = await api.flows.create_flow(
+            project_id=project_id, serialized_flow=flow.serialize()
+        )
+        await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
+        assert len(set((await api.flows.schedule_flow_runs(flow_id)))) == 10
+
+        await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).update(
+            set=dict(idempotency_key=None)
+        )
+        assert len(set((await api.flows.schedule_flow_runs(flow_id)))) == 0
+
 
 class TestScheduleRuns:
     async def test_schedule_runs(self, flow_id):

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1349,12 +1349,13 @@ class TestScheduledRunAttributes:
             project_id=project_id, serialized_flow=flow.serialize()
         )
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
-        assert len(set((await api.flows.schedule_flow_runs(flow_id)))) == 10
 
-        await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).update(
-            set=dict(idempotency_key=None)
-        )
-        assert len(set((await api.flows.schedule_flow_runs(flow_id)))) == 0
+        run_ids = set((await api.flows.schedule_flow_runs(flow_id)))
+        assert len(run_ids) == 10
+
+        run_ids_2 = set((await api.flows.schedule_flow_runs(flow_id)))
+
+        assert run_ids_2.issubset(run_ids)
 
 
 class TestScheduleRuns:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Through https://github.com/PrefectHQ/prefect/issues/3629 we observed that there is potential for duplicate runs to be scheduled due to expired idempotency keys (24 hours). To patch this behavior this PR moves the last scheduled run check to the step prior to creating an idempotency key based on the parameter defaults and labels.



## Importance
Duplicate runs are a hugely unexpected behavior and this patch is necessary.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
