### PR TITLE
Allow the scheduler to generate names based on the flow run name template

### DIFF
--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -550,7 +550,6 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
         apply_schema=False,
     )
 
-
     if not flow:
         logger.debug(f"Flow {flow_id} can not be scheduled.")
         return run_ids

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -601,7 +601,11 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             parameters=event.parameter_defaults,
             labels=event.labels,
             idempotency_key=idempotency_key,
-            flow_run_name=event.flow_run_name_template.format(**dict(event.parameter_defaults)) if event.flow_run_name_template is not None else None
+            flow_run_name=event.flow_run_name_template.format(
+                **dict(event.parameter_defaults)
+            )
+            if event.flow_run_name_template is not None
+            else None,
         )
 
         logger.debug(

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -550,6 +550,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
         apply_schema=False,
     )
 
+
     if not flow:
         logger.debug(f"Flow {flow_id} can not be scheduled.")
         return run_ids
@@ -601,6 +602,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             parameters=event.parameter_defaults,
             labels=event.labels,
             idempotency_key=idempotency_key,
+            flow_run_name=event.flow_run_name_template.format(**dict(event.parameter_defaults)) if event.flow_run_name_template is not None else None
         )
 
         logger.debug(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Utilizes the new `flow_run_name_template` on the `Clock` object to auto-generate flow run names based on parameter defaults. 

Blocked by: https://github.com/PrefectHQ/prefect/pull/3664

## Importance
<!-- Why is this PR important? -->
Flexibility for users!



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
