### PR TITLE
Fix handling for managed postgres usernames with `@` signs

### DIFF
--- a/changes/pr139.yaml
+++ b/changes/pr139.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix handling for managed postgres usernames with `@` signs - [#139](https://github.com/PrefectHQ/server/pull/139)"

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: PREFECT_SERVER_DB_CMD
               value: "echo 'DATABASE MIGRATIONS SKIPPED'"
             - name: PREFECT_SERVER__DATABASE__CONNECTION_URL
-              value: {{ include "prefect-server.postgres-connstr" . | replace "%40" "@" }}
+              value: {{ include "prefect-server.postgres-connstr" . }}
             - name: PGPASSWORD
               valueFrom:
                 {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}            

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - "/usr/local/bin/prefect-server database upgrade --yes"
           env:
             - name: PREFECT_SERVER__DATABASE__CONNECTION_URL
-              value: {{ include "prefect-server.postgres-connstr" . }}
+              value: {{ include "prefect-server.postgres-connstr" . | replace "%40" "@" }}
             - name: PGPASSWORD
               valueFrom:
                 {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
@@ -66,7 +66,7 @@ spec:
             - name: PREFECT_SERVER_DB_CMD
               value: "echo 'DATABASE MIGRATIONS SKIPPED'"
             - name: PREFECT_SERVER__DATABASE__CONNECTION_URL
-              value: {{ include "prefect-server.postgres-connstr" . }}
+              value: {{ include "prefect-server.postgres-connstr" . | replace "%40" "@" }}
             - name: PGPASSWORD
               valueFrom:
                 {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}            

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -25,9 +25,11 @@ postgresql:
   postgresqlDatabase: prefect
 
   # postgresqlUsername defines the username to authenticate
-  # with. If you are using Azure, this will include an '@'
+  # with.
+  # NOTE: If you are using Azure, this will include an '@'
   # which must be encoded as '%40' for the connection string
-  # to work with both Hasura and the Prefect GraphQL server
+  # to work with both Hasura, the GraphQL server, and the
+  # Alembic migration manager
   postgresqlUsername: prefect
 
   # existingSecret configures which secret should be referenced

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -23,6 +23,11 @@ annotations: {}
 # string
 postgresql:
   postgresqlDatabase: prefect
+
+  # postgresqlUsername defines the username to authenticate
+  # with. If you are using Azure, this will include an '@'
+  # which must be encoded as '%40' for the connection string
+  # to work with both Hasura and the Prefect GraphQL server
   postgresqlUsername: prefect
 
   # existingSecret configures which secret should be referenced


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Fixes database migration failures for Azure managed Postgres due to connection string issues.

Azure Postgres instances have usernames "user@instance-name" which requires escaping as "user%40instance-name" for Hasura (and other database connections) to work correctly. However, for migrations, an `@` is required in place of the `%40`


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
