### PR TITLE
Remove `database_url` from 'server database upgrade'

### DIFF
--- a/src/prefect_server/cli/database.py
+++ b/src/prefect_server/cli/database.py
@@ -80,12 +80,6 @@ def create(database_url):
 
 @database.command()
 @click.option(
-    "--database-url",
-    "-d",
-    help="The database connection URL",
-    default=prefect_server.config.database.connection_url,
-)
-@click.option(
     "-n",
     help="The argument to `alembic upgrade`. If not provided, runs all.",
     default=None,

--- a/src/prefect_server/cli/database.py
+++ b/src/prefect_server/cli/database.py
@@ -90,7 +90,7 @@ def create(database_url):
     help="Pass --yes to confirm that you want to upgrade the database",
     is_flag=True,
 )
-def upgrade(database_url, yes, n=None):
+def upgrade(yes, n=None):
     """
     Upgrades the Prefect database by running any Alembic migrations
     """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Removes the unused `database_url` option which does not have any effect because the database connstr is loaded in `services/postgres/alembic/env.py`

## Importance
<!-- Why is this PR important? -->

Misleading to have it but not have it work. Dangerous for migrations.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
