### PR TITLE
Add support for configurable primary keys on ORM models

### DIFF
--- a/changes/pr145.yaml
+++ b/changes/pr145.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Support configurable primary keys in ORM - [#145](https://github.com/PrefectHQ/server/pull/145)"

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -470,7 +470,7 @@ class ModelQuery:
         arguments = {}
 
         if selection_set is None:
-            selection_set = self.__primary_key__
+            selection_set = self.model.__primary_key__
 
         if self.where is not None:
             arguments["where"] = self.where
@@ -518,7 +518,7 @@ class ModelQuery:
             - dict: the fields in the `selection_set`
         """
         if selection_set is None:
-            selection_set = self.__primary_key__
+            selection_set = self.model.__primary_key__
         result = await self.get(
             selection_set=selection_set,
             limit=1,

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import uuid
-from typing import List, Union, cast
+from typing import List, Union, cast, Any
 
 import pendulum
 import psycopg2
@@ -54,6 +54,13 @@ class ORMModel(pydantic.BaseModel):
     A Pydantic model that defaults to only including set fields,
     which is helpful when working with subsets of available data.
     """
+
+    # the model primary key
+    __primary_key__ = "id"
+
+    @property
+    def primary_key(self) -> Any:
+        return getattr(self, self.__primary_key__)
 
     def __repr_args__(self) -> List:
         """
@@ -194,7 +201,7 @@ class HasuraModel(ORMModel):
         """
         if selection_set is None:
             return_id = True
-            selection_set = {"returning": "id"}
+            selection_set = {"returning": self.__primary_key__}
         else:
             return_id = False
 
@@ -212,7 +219,7 @@ class HasuraModel(ORMModel):
             if "returning" in result:
                 result["returning"] = result["returning"][0]
             if return_id:
-                return result["returning"]["id"]
+                return result["returning"][self.__primary_key__]
         return result
 
     async def delete(
@@ -235,9 +242,6 @@ class HasuraModel(ORMModel):
             - dict: the fields in the `selection_set`
         """
 
-        if not hasattr(self, "id"):
-            raise ValueError("This instance has no ID; can not delete.")
-
         if selection_set is None:
             check_result = True
             selection_set = "affected_rows"
@@ -246,7 +250,9 @@ class HasuraModel(ORMModel):
 
         result = await prefect.plugins.hasura.client.delete(
             graphql_type=self.__hasura_type__,
-            id=str(self.id) if isinstance(self.id, uuid.UUID) else self.id,
+            id=str(self.primary_key)
+            if isinstance(self.primary_key, uuid.UUID)
+            else self.primary_key,
             selection_set=selection_set,
             alias=alias,
             run_mutation=run_mutation,
@@ -283,7 +289,7 @@ class HasuraModel(ORMModel):
 
         if selection_set is None:
             return_id = True
-            selection_set = {"returning": "id"}
+            selection_set = {"returning": self.__primary_key__}
         else:
             return_id = False
 
@@ -302,7 +308,7 @@ class HasuraModel(ORMModel):
             run_mutation=run_mutation,
         )
         if run_mutation and return_id:
-            return [r["id"] for r in result["returning"]]
+            return [r[self.__primary_key__] for r in result["returning"]]
         return result
 
     @classmethod
@@ -347,7 +353,7 @@ class HasuraModel(ORMModel):
             raise ValueError("The provided id was `None`, which is an invalid value.")
         # otherwise check if an ID was provided
         elif id is not sentinel:
-            where.update({"id": {"_eq": id}})
+            where.update({self.__primary_key__: {"_eq": id}})
         return ModelQuery(model=cls, where=where)
 
 
@@ -464,7 +470,7 @@ class ModelQuery:
         arguments = {}
 
         if selection_set is None:
-            selection_set = "id"
+            selection_set = self.__primary_key__
 
         if self.where is not None:
             arguments["where"] = self.where
@@ -512,7 +518,7 @@ class ModelQuery:
             - dict: the fields in the `selection_set`
         """
         if selection_set is None:
-            selection_set = "id"
+            selection_set = self.__primary_key__
         result = await self.get(
             selection_set=selection_set,
             limit=1,

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -289,7 +289,7 @@ class HasuraModel(ORMModel):
 
         if selection_set is None:
             return_id = True
-            selection_set = {"returning": self.__primary_key__}
+            selection_set = {"returning": cls.__primary_key__}
         else:
             return_id = False
 
@@ -308,7 +308,7 @@ class HasuraModel(ORMModel):
             run_mutation=run_mutation,
         )
         if run_mutation and return_id:
-            return [r[self.__primary_key__] for r in result["returning"]]
+            return [r[cls.__primary_key__] for r in result["returning"]]
         return result
 
     @classmethod
@@ -353,7 +353,7 @@ class HasuraModel(ORMModel):
             raise ValueError("The provided id was `None`, which is an invalid value.")
         # otherwise check if an ID was provided
         elif id is not sentinel:
-            where.update({self.__primary_key__: {"_eq": id}})
+            where.update({cls.__primary_key__: {"_eq": id}})
         return ModelQuery(model=cls, where=where)
 
 

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -97,6 +97,20 @@ class TestModel:
             "child": {"data": {"grandchildren": {"data": [{"x": 1}, {"x": 2}]}}}
         }
 
+    def test_primary_key_property(self):
+        class Model(orm.HasuraModel):
+
+            id: int
+            custom_id: int
+
+        class CustomModel(orm.HasuraModel):
+            __primary_key__ = "custom_id"
+            id: int
+            custom_id: int
+
+        assert Model(id=1, custom_id=2).primary_key == 1
+        assert CustomModel(id=1, custom_id=2).primary_key == 2
+
 
 class TestFields:
     async def test_UUIDString_is_a_string(self):


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
As we make heavier use of views, the assumption that every model has a corresponding `id` key is more likely to be validated. This PR makes each ORM model's primary key configurable. It does not replace existing uses of the word "id" as an argument (`models.Flow.where(id=5)`) because the headache would be... too much. However, `models.CustomFlow.where(id=5)` would work even if CustomFlow's primary key were a field other than `id`.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
