### PR TITLE
Add index on task run names for global search

### DIFF
--- a/services/postgres/alembic/versions/2020-12-02T130956_add_index_for_task_run_names.py
+++ b/services/postgres/alembic/versions/2020-12-02T130956_add_index_for_task_run_names.py
@@ -19,12 +19,15 @@ depends_on = None
 
 
 def upgrade():
-    op.create_index(
-        "ix_task_run_name",
-        "task_run",
-        ["name"],
+    op.execute(
+        """
+        CREATE INDEX
+        ix_task_run_name_trgm
+        ON task_run USING GIN (name gin_trgm_ops)
+        WHERE name IS NOT NULL
+        """
     )
 
 
 def downgrade():
-    op.drop_index("ix_task_run_name", table_name="task_run")
+    op.drop_index("ix_task_run_name_trgm", table_name="task_run")

--- a/services/postgres/alembic/versions/2020-12-02T130956_add_index_for_task_run_names.py
+++ b/services/postgres/alembic/versions/2020-12-02T130956_add_index_for_task_run_names.py
@@ -1,0 +1,30 @@
+"""
+Add index for task run names
+
+Revision ID: 57ac2cb01ac1
+Revises: 3c87ad7e0b71
+Create Date: 2020-12-02 13:09:56.377051
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "57ac2cb01ac1"
+down_revision = "3c87ad7e0b71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_task_run_name",
+        "task_run",
+        ["name"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_task_run_name", table_name="task_run")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Corresponding to https://github.com/PrefectHQ/cloud/pull/2884 adds a GIN trigram text search index on task run names

## Importance
<!-- Why is this PR important? -->

Necessary for reasonable global search of task run names

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [ ] adds a change file in the `changes/` directory (if appropriate)
