### PR TITLE
Support null environment & run_config

### DIFF
--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -180,8 +180,10 @@ async def _create_flow_run(
         run_labels = flow.flow_group.labels
     elif flow.run_config is not None:
         run_labels = flow.run_config.get("labels") or []
-    else:
+    elif flow.environment is not None:
         run_labels = flow.environment.get("labels") or []
+    else:
+        run_labels = []
     run_labels.sort()
 
     # check parameters


### PR DESCRIPTION
Flows serialized by `prefect` should always have an `environment` and/or
a `run_config` present, but this isn't enforced by the schema. This adds
a quick fix to support flows with both `run_config` and `environment` as
`None`, to match the behavior of the cloud api (which already has this
fix).
