### PR TITLE
Add jobs/status to role for agent

### DIFF
--- a/changes/pr-154.yaml
+++ b/changes/pr-154.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Add jobs/status to role for agent - [#154](https://github.com/PrefectHQ/server/pull/154)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/helm/prefect-server/templates/agent/rbac.yaml
+++ b/helm/prefect-server/templates/agent/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - extensions
   resources:
   - jobs
+  - jobs/status
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Enables agent role to get jobs/status.



## Importance
<!-- Why is this PR important? -->

Otherwise Prefect task RunNamespacedJob fail because it try to get the status of a job.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
