### PR TITLE
Add events resource to Kubernetes Agent RBAC helm chart template

### DIFF
--- a/changes/pr157.yaml
+++ b/changes/pr157.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add the `events` RBAC permission to agents created by the helm chart - [#157](https://github.com/PrefectHQ/cloud/pull/157)"

--- a/helm/prefect-server/templates/agent/rbac.yaml
+++ b/helm/prefect-server/templates/agent/rbac.yaml
@@ -21,6 +21,7 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - events
   - pods
   verbs:
   - '*'


### PR DESCRIPTION
The next release of core will allow agents to report events for pending pods that belong to jobs it creates. (PrefectHQ/prefect#3783) In order to use this functionality the in-cluster agent in the helm chart should have the proper resources in the RBAC.