### PR TITLE
Add support for custom Hasura root fields

### DIFF
--- a/changes/pr161.yaml
+++ b/changes/pr161.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add support for custom Hasura root fields - [#161](https://github.com/PrefectHQ/server/pull/161)"

--- a/src/prefect_server/database/hasura.py
+++ b/src/prefect_server/database/hasura.py
@@ -198,6 +198,7 @@ class HasuraClient(GraphQLClient):
         alias: str = None,
         selection_set: GQLObjectTypes = "affected_rows",
         run_mutation: bool = True,
+        insert_mutation_name: str = None,
     ) -> Box:
         """
         Runs an `insert` mutation against the provided Hasura type, evaluating the provided
@@ -206,6 +207,9 @@ class HasuraClient(GraphQLClient):
         The `selection_set` is inserted directly into the graphql query, and should not
         be surrounded by curly braces. Valid top-level keys are `affected_rows` and `returning`.
         """
+
+        if insert_mutation_name is None:
+            insert_mutation_name = f"insert_{graphql_type}"
 
         if not isinstance(objects, (list, set, tuple)):
             raise TypeError(
@@ -244,7 +248,7 @@ class HasuraClient(GraphQLClient):
         # -------------------------------------------------------------
         # build mutation
 
-        mutation_name = f"{alias}: insert_{graphql_type}"
+        mutation_name = f"{alias}: {insert_mutation_name}"
         selection_set = selection_set or "affected_rows"
 
         graphql = dict(
@@ -266,6 +270,7 @@ class HasuraClient(GraphQLClient):
         alias: str = None,
         selection_set: GQLObjectTypes = "affected_rows",
         run_mutation: bool = True,
+        delete_mutation_name: str = None,
     ) -> Box:
         """
         Runs an `delete` mutation against the provided Hasura type and `where` clause,
@@ -279,6 +284,9 @@ class HasuraClient(GraphQLClient):
                 "`where` must be provided as a dict if `id` is None; "
                 f"received {type(where).__name__}"
             )
+
+        if delete_mutation_name is None:
+            delete_mutation_name = f"delete_{graphql_type}"
 
         where = where or {}
         if id is not None:
@@ -301,7 +309,7 @@ class HasuraClient(GraphQLClient):
         # -------------------------------------------------------------
         # build mutation
 
-        mutation_name = f"{alias}: delete_{graphql_type}"
+        mutation_name = f"{alias}: {delete_mutation_name}"
         selection_set = selection_set or "affected_rows"
         graphql = dict(
             query={with_args(mutation_name, arguments): selection_set},
@@ -328,6 +336,7 @@ class HasuraClient(GraphQLClient):
         selection_set: GQLObjectTypes = "affected_rows",
         alias: str = None,
         run_mutation: bool = True,
+        update_mutation_name: str = None,
     ) -> Box:
         """
         Runs an `update` mutation against the provided Hasura type and `where` clause, applying
@@ -352,6 +361,8 @@ class HasuraClient(GraphQLClient):
             - alias (str): a GraphQL alias, useful when running this mutation in a batch.
             - run_mutation (bool): if True (default), the mutation is run immediately. If False,
                 an object is returned that can be passed to `HasuraClient.execute_mutations_in_transaction`.
+            - update_mutation_name (str): if provided, the name of the mutation. Otherwise inferred
+                from the graphql_type. This is useful if custom root mutations were created.
 
         """
         if id is None and not isinstance(where, dict):
@@ -364,6 +375,9 @@ class HasuraClient(GraphQLClient):
             for op in [set, increment, append, prepend, delete_key, delete_elem]
         ):
             raise ValueError("At least one update operation must be provided")
+
+        if update_mutation_name is None:
+            update_mutation_name = f"update_{graphql_type}"
 
         where = where or {}
 
@@ -444,7 +458,7 @@ class HasuraClient(GraphQLClient):
         # -------------------------------------------------------------
         # build mutation
 
-        mutation_name = f"{alias}: update_{graphql_type}"
+        mutation_name = f"{alias}: {update_mutation_name}"
         selection_set = selection_set or "affected_rows"
         graphql = dict(
             query={with_args(mutation_name, arguments): selection_set},

--- a/src/prefect_server/database/hasura.py
+++ b/src/prefect_server/database/hasura.py
@@ -24,7 +24,7 @@ class Variable:
         return f"${self.name}"
 
     def __repr__(self) -> str:
-        return f"<GraphQL Variable: {self.name}>"
+        return f'<GraphQL Variable "{self.name}": {self.type}>'
 
     def __hash__(self) -> int:
         return id(self)
@@ -302,7 +302,9 @@ class HasuraClient(GraphQLClient):
         # --- variable: where
 
         arguments["where"] = Variable(
-            name=f"{alias}_where", type=f"{graphql_type}_bool_exp!", value=where
+            name=f"{alias}_where",
+            type=f"{graphql_type}_bool_exp!",
+            value=where,
         )
         variables.append(arguments["where"])
 
@@ -395,7 +397,9 @@ class HasuraClient(GraphQLClient):
         # --- variable: where
 
         arguments["where"] = Variable(
-            name=f"{alias}_where", type=f"{graphql_type}_bool_exp!", value=where
+            name=f"{alias}_where",
+            type=f"{graphql_type}_bool_exp!",
+            value=where,
         )
         variables.append(arguments["where"])
 
@@ -403,7 +407,9 @@ class HasuraClient(GraphQLClient):
 
         if set:
             arguments["_set"] = Variable(
-                name=f"{alias}_set", type=f"{graphql_type}_set_input", value=set
+                name=f"{alias}_set",
+                type=f"{graphql_type}_set_input",
+                value=set,
             )
             variables.append(arguments["_set"])
 
@@ -411,7 +417,9 @@ class HasuraClient(GraphQLClient):
 
         if increment:
             arguments["_inc"] = Variable(
-                name=f"{alias}_inc", type=f"{graphql_type}_inc_input", value=increment
+                name=f"{alias}_inc",
+                type=f"{graphql_type}_inc_input",
+                value=increment,
             )
             variables.append(arguments["_inc"])
 

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -512,12 +512,12 @@ class ModelQuery:
             obj = with_args(obj, arguments)
 
         result = await prefect.plugins.hasura.client.execute(
-            query={"query": {obj: selection_set}},
+            query={"query": {f"select: {obj}": selection_set}},
             # if we are applying the schema, don't retrieve a box object
             # if we are NOT applying the schema, DO retrieve a box object
             as_box=not apply_schema,
         )
-        data = result["data"][self.model.__hasura_type__]
+        data = result["data"]["select"]
         if apply_schema:
             return [self.model(**d) for d in data]
         else:

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -264,7 +264,7 @@ class HasuraModel(ORMModel):
             selection_set=selection_set,
             alias=alias,
             run_mutation=run_mutation,
-            insert_mutation_name=self.__root_fields__.get("insert"),
+            delete_mutation_name=self.__root_fields__.get("delete"),
         )
 
         if run_mutation and check_result:

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -495,7 +495,7 @@ class TestRootFields:
         mock = CoroutineMock()
         monkeypatch.setattr("prefect_server.database.hasura.HasuraClient.execute", mock)
         graphql = await self.TestModel().where().get()
-        assert mock.awaited_once_with(query={"query": {"abc(where: {})": "id"}})
+        assert mock.awaited_once_with(query={"query": {"select: abc(where: {})": "id"}})
 
     async def test_get_select_aggregate_root_field_graphql(self, monkeypatch):
         mock = CoroutineMock()
@@ -544,7 +544,11 @@ class TestRootFields:
     async def test_get_custom_update_root_field_graphql(self):
         graphql = await self.TestCustomModel().where().update(run_mutation=False)
         assert next(iter(graphql["query"])).startswith("update: custom_update_xyz(")
+        # recover correct fields for non-root types
+        assert graphql["variables"][0].type == "abc_bool_exp!"
 
     async def test_get_custom_delete_root_field_graphql(self):
         graphql = await self.TestCustomModel().where().delete(run_mutation=False)
         assert next(iter(graphql["query"])).startswith("delete: custom_delete_xyz(")
+        # recover correct fields for non-root types
+        assert graphql["variables"][0].type == "abc_bool_exp!"

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -1,7 +1,7 @@
 # Licensed under the Prefect Community License, available at
 # https://www.prefect.io/legal/prefect-community-license
 
-
+from asynctest import CoroutineMock
 import datetime
 import json
 import uuid
@@ -470,3 +470,81 @@ class TestRunModels:
         assert info["message"] == state.message
         assert info["result"] == state.result
         assert info["serialized_state"] == state.serialize()
+
+
+class TestRootFields:
+    class TestModel(orm.HasuraModel):
+        __hasura_type__ = "abc"
+        __root_fields__ = {}
+
+    class TestCustomModel(orm.HasuraModel):
+        __hasura_type__ = "abc"
+        __root_fields__ = {
+            "select": "custom_select_xyz",
+            "select_aggregate": "custom_select_aggregate_xyz",
+            "insert": "custom_insert_xyz",
+            "update": "custom_update_xyz",
+            "delete": "custom_delete_xyz",
+        }
+
+    # --------------------
+    # inferred root fields
+    # --------------------
+
+    async def test_get_select_root_field_graphql(self, monkeypatch):
+        mock = CoroutineMock()
+        monkeypatch.setattr("prefect_server.database.hasura.HasuraClient.execute", mock)
+        graphql = await self.TestModel().where().get()
+        assert mock.awaited_once_with(query={"query": {"abc(where: {})": "id"}})
+
+    async def test_get_select_aggregate_root_field_graphql(self, monkeypatch):
+        mock = CoroutineMock()
+        monkeypatch.setattr("prefect_server.database.hasura.HasuraClient.execute", mock)
+        graphql = await self.TestModel().where().get()
+        assert mock.awaited_once_with(
+            query={"count": {"abc_aggregate(where: {})": "id"}}
+        )
+
+    async def test_get_insert_root_field_graphql(self):
+        graphql = await self.TestModel().insert_many([], run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("insert: insert_abc(")
+
+    async def test_get_update_root_field_graphql(self):
+        graphql = await self.TestModel().where().update(run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("update: update_abc(")
+
+    async def test_get_delete_root_field_graphql(self):
+        graphql = await self.TestModel().where().delete(run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("delete: delete_abc(")
+
+    # --------------------
+    # custom root fields
+    # --------------------
+
+    async def test_get_custom_select_root_field_graphql(self, monkeypatch):
+        mock = CoroutineMock()
+        monkeypatch.setattr("prefect_server.database.hasura.HasuraClient.execute", mock)
+        graphql = await self.TestCustomModel().where().get()
+        assert mock.awaited_once_with(
+            query={"query": {"custom_select_xyz(where: {})": "id"}}
+        )
+
+    async def test_get_custom_select_aggregate_root_field_graphql(self, monkeypatch):
+        mock = CoroutineMock()
+        monkeypatch.setattr("prefect_server.database.hasura.HasuraClient.execute", mock)
+        graphql = await self.TestCustomModel().where().get()
+        assert mock.awaited_once_with(
+            query={"count": {"custom_select_aggregate_xyz(where: {})": "id"}}
+        )
+
+    async def test_get_custom_insert_root_field_graphql(self):
+        graphql = await self.TestCustomModel().insert_many([], run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("insert: custom_insert_xyz(")
+
+    async def test_get_custom_update_root_field_graphql(self):
+        graphql = await self.TestCustomModel().where().update(run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("update: custom_update_xyz(")
+
+    async def test_get_custom_delete_root_field_graphql(self):
+        graphql = await self.TestCustomModel().where().delete(run_mutation=False)
+        assert next(iter(graphql["query"])).startswith("delete: custom_delete_xyz(")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Hasura supports custom root fields, which is now enabled in the ORM.

```python

class MyHasuraModel(HasuraModel):
	__hasura_type__ = "flow"
	__root_fields__ = {
		'insert': 'custom_insert_flow_root_type',
        'delete': 'delete_some_flows'
	}
	...
```



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
