### PR TITLE
Remove .get() and .exists() methods on hasura client

### DIFF
--- a/src/prefect_server/database/hasura.py
+++ b/src/prefect_server/database/hasura.py
@@ -167,29 +167,6 @@ class HasuraClient(GraphQLClient):
 
         return result
 
-    async def get(
-        self, graphql_type: str, id: str, selection_set: GQLObjectTypes
-    ) -> Box:
-        """
-        Query a specific object type by ID
-
-        Args:
-            - graphql_type(str): the GraphQL type to query
-            - id (str): the object ID
-            - selection_set (str): a GraphQL results query, not including surrounding braces
-        """
-        query_type = f"{graphql_type}_by_pk"
-        query = {"query": {with_args(query_type, {"id": id}): selection_set}}
-        result = await self.execute(query)
-        return result.data[query_type]
-
-    async def exists(self, graphql_type: str, id: str) -> bool:
-        """
-        Tests if a type with the provided ID exists in the database
-        """
-        result = await self.get(graphql_type=graphql_type, id=id, selection_set="id")
-        return result is not None
-
     async def insert(
         self,
         graphql_type: str,

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -332,11 +332,7 @@ class HasuraModel(ORMModel):
         Returns:
             - bool: True if the object exists; False otherwise
         """
-        if isinstance(id, uuid.UUID):
-            id = str(id)
-        return await prefect.plugins.hasura.client.exists(
-            graphql_type=cls.__hasura_type__, id=id
-        )
+        return bool(cls.where(id=id).first())
 
     @classmethod
     def where(cls, where: GQLObjectTypes = None, id: str = sentinel) -> "ModelQuery":

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -322,19 +322,6 @@ class HasuraModel(ORMModel):
         return result
 
     @classmethod
-    async def exists(cls, id: str) -> bool:
-        """
-        Returns True if an object with the specified ID exists in the database; False otherwise.
-
-        Args:
-            - id (str): an object with this ID will be tested
-
-        Returns:
-            - bool: True if the object exists; False otherwise
-        """
-        return bool(cls.where(id=id).first())
-
-    @classmethod
     def where(cls, where: GQLObjectTypes = None, id: str = sentinel) -> "ModelQuery":
         """
         Constructs a "where" clause for this object type, allowing mutations like `update` and

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -50,7 +50,7 @@ class TestCreateFlow:
         flow_id = await api.flows.create_flow(
             project_id=project_id, serialized_flow=flow.serialize()
         )
-        assert await models.Flow.exists(flow_id)
+        assert await models.Flow.where(id=flow_id).first()
 
     async def test_create_flow_with_no_schedule_sets_schedule_inactive(
         self, project_id, flow
@@ -131,7 +131,7 @@ class TestCreateFlow:
         flow_id = await api.flows.create_flow(
             project_id=project_id, serialized_flow=prefect.Flow(name="test").serialize()
         )
-        assert await models.Flow.exists(flow_id)
+        assert await models.Flow.where(id=flow_id).first()
 
     async def test_create_flow_without_edges(self, project_id):
         flow = prefect.Flow(name="test")
@@ -141,7 +141,7 @@ class TestCreateFlow:
         flow_id = await api.flows.create_flow(
             project_id=project_id, serialized_flow=prefect.Flow(name="test").serialize()
         )
-        assert await models.Flow.exists(flow_id)
+        assert await models.Flow.where(id=flow_id).first()
 
     async def test_create_flow_also_creates_tasks(self, project_id, flow):
         flow_id = await api.flows.create_flow(

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -814,11 +814,11 @@ class TestUnarchiveFlow:
 class TestDeleteFlow:
     async def test_delete_tenant_deletes_flow(self, tenant_id, flow_id):
         await models.Tenant.where(id=tenant_id).delete()
-        assert not await models.Flow.exists(flow_id)
+        assert not await models.Flow.where(id=flow_id).first()
 
     async def test_delete_flow_does_not_delete_tenant(self, tenant_id, flow_id):
         assert await api.flows.delete_flow(flow_id)
-        assert await models.Tenant.exists(tenant_id)
+        assert await models.Tenant.where(id=tenant_id).first()
 
     async def test_delete_flow_deletes_flow_runs(self, flow_id, flow_run_id):
         await api.states.set_flow_run_state(
@@ -826,11 +826,11 @@ class TestDeleteFlow:
             state=prefect.engine.state.Scheduled(),
         )
 
-        assert await models.FlowRun.exists(flow_run_id)
+        assert await models.FlowRun.where(id=flow_run_id).first()
 
         assert await api.flows.delete_flow(flow_id)
 
-        assert not await models.FlowRun.exists(flow_run_id)
+        assert not await models.FlowRun.where(id=flow_run_id).first()
 
     async def test_delete_flow_with_none_id(self):
         with pytest.raises(ValueError, match="Must provide flow ID."):

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -9,7 +9,7 @@ class TestCreateProject:
     async def test_create_project(self, tenant_id):
         project_id = await api.projects.create_project(tenant_id=tenant_id, name="test")
 
-        assert await models.Project.exists(project_id)
+        assert await models.Project.where(id=project_id).first()
         project = await models.Project.where(id=project_id).first({"name"})
         assert project.name == "test"
 
@@ -18,7 +18,7 @@ class TestCreateProject:
             tenant_id=tenant_id, name="test", description="test-description"
         )
 
-        assert await models.Project.exists(project_id)
+        assert await models.Project.where(id=project_id).first()
         project = await models.Project.where(id=project_id).first(
             {"name", "description"}
         )
@@ -30,29 +30,25 @@ class TestCreateProject:
         with pytest.raises(ValueError):
             await api.projects.create_project(tenant_id=tenant_id, name="test")
 
-    async def test_delete_project_deletes_flow(self, project_id, flow_id, tenant_id):
-        await models.Project.where(id=project_id).delete()
-        assert not await models.Project.exists(flow_id)
-
     async def test_same_project_name_in_multiple_tenants(self, tenant_id):
         tenant_id_2 = await api.tenants.create_tenant(name="name")
         p1 = await api.projects.create_project(tenant_id=tenant_id, name="test")
         p2 = await api.projects.create_project(tenant_id=tenant_id_2, name="test")
 
-        assert await models.Project.exists(p1)
-        assert await models.Project.exists(p2)
+        assert await models.Project.where(id=p1).first()
+        assert await models.Project.where(id=p2).first()
 
     async def test_delete_tenant_deletes_project(self, tenant_id, project_id):
         await models.Tenant.where(id=tenant_id).delete()
-        assert not await models.Project.exists(project_id)
+        assert not await models.Project.where(id=project_id).first()
 
     async def test_delete_project_does_not_delete_tenant(self, tenant_id, project_id):
         await models.Project.where(id=project_id).delete()
-        assert await models.Tenant.exists(tenant_id)
+        assert await models.Tenant.where(id=tenant_id).first()
 
     async def test_delete_project_deletes_flow(self, project_id, flow_id):
         await models.Project.where(id=project_id).delete()
-        assert not await models.Project.exists(flow_id)
+        assert not await models.Flow.where(id=flow_id).first()
 
 
 class TestSetProjectName:

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -29,7 +29,7 @@ async def simple_flow_id(project_id):
 class TestCreateRun:
     async def test_create_flow_run(self, simple_flow_id):
         flow_run_id = await api.runs.create_flow_run(flow_id=simple_flow_id)
-        assert await models.FlowRun.exists(flow_run_id)
+        assert await models.FlowRun.where(id=flow_run_id).first()
 
     async def test_create_flow_run_accepts_labels(self, simple_flow_id):
         flow_run_id = await api.runs.create_flow_run(
@@ -493,7 +493,7 @@ class TestGetTaskRunInfo:
         tr_id = await api.runs.get_or_create_task_run(
             flow_run_id=flow_run_id, task_id=task_id, map_index=None
         )
-        assert await models.TaskRun.exists(tr_id)
+        assert await models.TaskRun.where(id=tr_id).first()
 
     async def test_task_run_populates_cache_key(self, flow_run_id, task_id):
         cache_key = "test"
@@ -556,7 +556,7 @@ class TestGetTaskRunInfo:
         tr_id = await api.runs.get_or_create_task_run(
             flow_run_id=flow_run_id, task_id=task_id, map_index=10
         )
-        assert await models.TaskRun.exists(tr_id)
+        assert await models.TaskRun.where(id=tr_id).first()
 
     async def test_task_run_fails_with_fake_flow_run_id(self, task_id):
         with pytest.raises(ValueError, match="Invalid ID"):

--- a/tests/api/test_tenants.py
+++ b/tests/api/test_tenants.py
@@ -15,7 +15,7 @@ class TestCreateTenant:
         slug = random_id()
 
         tenant_id = await api.tenants.create_tenant(name=name, slug=slug)
-        assert await models.Tenant.exists(tenant_id)
+        assert await models.Tenant.where(id=tenant_id).first()
 
     async def test_create_tenant_stores_attributes(self):
         name = random_id()

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -248,10 +248,10 @@ class TestORM:
         assert next(iter(graphql["query"])).startswith("x: delete_project(")
 
     async def test_exists(self, project_id):
-        assert await models.Project.exists(project_id)
+        assert await models.Project.where(id=project_id).first()
 
     async def test_exists_false(self):
-        assert not await models.Project.exists(uuid.uuid4())
+        assert not await models.Project.where(id=uuid.uuid4()).first()
 
     async def test_where_is_modelquery(self):
         assert isinstance(models.Project.where(), orm.ModelQuery)
@@ -282,21 +282,21 @@ class TestORM:
         f3 = models.Project(name="f3")
         ids = await models.Project.insert_many([f1, f2, f3])
         assert len(ids) == 3
-        assert all([await models.Project.exists(i) for i in ids])
+        assert all([await models.Project.where(id=i).first() for i in ids])
 
     async def test_insert_dict(self, project_id):
         f1 = dict(name="f1")
         f2 = dict(name="f2")
         f3 = dict(name="f3")
         ids = await models.Project.insert_many([f1, f2, f3])
-        assert all([await models.Project.exists(i) for i in ids])
+        assert all([await models.Project.where(id=i).first() for i in ids])
 
     async def test_insert_dict_with_apply_schema(self, project_id):
         f1 = dict(name="f1")
         f2 = dict(name="f2")
         f3 = dict(name="f3")
         ids = await models.Project.insert_many([f1, f2, f3])
-        assert all([await models.Project.exists(i) for i in ids])
+        assert all([await models.Project.where(id=i).first() for i in ids])
 
     async def test_get_more_than_100_objects(self, project_id):
         await models.Project.where().delete()

--- a/tests/graphql/test_flows.py
+++ b/tests/graphql/test_flows.py
@@ -33,7 +33,6 @@ class TestCreateFlow:
                 input=dict(serialized_flow=serialized_flow, project_id=project_id)
             ),
         )
-        assert await models.Flow.exists(result.data.create_flow.id)
         flow = await models.Flow.where(id=result.data.create_flow.id).first(
             {"project_id"}
         )
@@ -46,9 +45,6 @@ class TestCreateFlow:
             variables=dict(
                 input=dict(serialized_flow=serialized_flow, project_id=project_id)
             ),
-        )
-        assert await models.Flow.exists(
-            result.data.create_flow_from_compressed_string.id
         )
         flow = await models.Flow.where(
             id=result.data.create_flow_from_compressed_string.id
@@ -344,7 +340,7 @@ class TestDeleteFlow:
             query=self.mutation,
             variables=dict(input=dict(flow_id=flow_id)),
         )
-        assert not await models.Flow.exists(flow_id)
+        assert not await models.Flow.where(id=flow_id).first()
 
 
 class TestArchiveFlow:

--- a/tests/graphql/test_projects.py
+++ b/tests/graphql/test_projects.py
@@ -17,7 +17,6 @@ class TestCreateProject:
             query=self.mutation,
             variables=dict(input=dict(tenant_id=tenant_id, name="test-gql")),
         )
-        assert await models.Project.exists(result.data.create_project.id)
         project = await models.Project.where(id=result.data.create_project.id).first(
             {"name"}
         )
@@ -66,7 +65,7 @@ class TestDeleteProject:
             variables=dict(input=(dict(project_id=project_id))),
         )
         assert result.data.delete_project.success
-        assert not await models.Project.exists(project_id)
+        assert not await models.Project.where(id=project_id).first()
 
     async def test_delete_project_bad_id(self, run_query, project_id):
         result = await run_query(

--- a/tests/graphql/test_runs.py
+++ b/tests/graphql/test_runs.py
@@ -408,7 +408,7 @@ class TestDeleteFlowRun:
         )
 
         assert result.data.delete_flow_run.success
-        assert not await models.FlowRun.exists(flow_run_id)
+        assert not await models.FlowRun.where(id=flow_run_id).first()
 
     async def test_delete_flow_run_bad_id(self, run_query):
         result = await run_query(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Closes #160 

Removes `.get()` and `.exists()` from the Hasura client (both brittle fields that depended on `by_pk` queries and were almost unused), as well as `.exists()` from the ORM, as it is easily replaced with `.where(id=id).first()`.




## Importance
<!-- Why is this PR important? -->
Removing brittle methods and dependencies on Hasura implementation details (like `by_pk`)



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
