### PR TITLE
Helm: configure strategy for deployment

### DIFF
--- a/changes/pr165.yaml
+++ b/changes/pr165.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Helm: configure strategy for deployment - [#165](https://github.com/PrefectHQ/server/pull/165)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- merge .Values.agent.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.agent.replicas }}
+  {{- with .Values.agent.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/templates/apollo/deployment.yaml
+++ b/helm/prefect-server/templates/apollo/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- merge .Values.apollo.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.apollo.replicas }}
+  {{- with .Values.apollo.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- merge .Values.graphql.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.graphql.replicas }}
+  {{- with .Values.graphql.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/templates/hasura/deployment.yaml
+++ b/helm/prefect-server/templates/hasura/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- merge .Values.hasura.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.hasura.replicas }}
+  {{- with .Values.hasura.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/templates/towel/deployment.yaml
+++ b/helm/prefect-server/templates/towel/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- merge .Values.towel.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.towel.replicas }}
+  {{- with .Values.towel.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- merge .Values.ui.annotations .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.ui.replicas }}
+  {{- with .Values.ui.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prefect-server.matchLabels" . | nindent 6 }}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -131,6 +131,7 @@ hasura:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -156,6 +157,7 @@ graphql:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -190,6 +192,7 @@ apollo:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -221,6 +224,7 @@ ui:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -240,6 +244,7 @@ towel:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   resources: {}
@@ -269,6 +274,7 @@ agent:
   labels: {}
   annotations: {}
   replicas: 1
+  strategy: {}
   podSecurityContext: {}
   securityContext: {}
   nodeSelector: {}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds the possibility to the helm chart to configure the strategy of deployment.



## Importance
<!-- Why is this PR important? -->

Allows to configure rolling updates, for instance maybe someone (me) wants to tune the surge and unavailable parameters. Example of `values.yaml`

```
apollo:
  replicas: 3
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1

  affinity: 
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: app.kubernetes.io/component
            operator: In
            values:
            - apollo
        topologyKey: kubernetes.io/hostname
```


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
