### PR TITLE
Use `pull_request_target` in labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler/blob/master/README.md
 
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
Should allow running labeler on PRs from forks.