### PR TITLE
Flow Group schedule timezones

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## December 16, 2020 <Badge text="beta" type="success" />
+
+Released on December 16, 2020.
+
+### Enhancements
+
+- Add the `events` RBAC permission to agents created by the helm chart - [#157](https://github.com/PrefectHQ/cloud/pull/157)
+
 ## December 14, 2020 <Badge text="beta" type="success" />
 
 Released on December 14, 2020.

--- a/changes/pr157.yaml
+++ b/changes/pr157.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Add the `events` RBAC permission to agents created by the helm chart - [#157](https://github.com/PrefectHQ/cloud/pull/157)"

--- a/changes/pr169.yaml
+++ b/changes/pr169.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Allow for timezone specification on flow group schedules - [#169](https://github.com/PrefectHQ/server/pull/169)"

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -89,7 +89,7 @@ async def set_flow_group_schedule(
         if timezone not in pendulum.timezones:
             raise ValueError(f"Invalid timezone provided for schedule: {timezone}")
         start_date = {
-            "dt": pendulum.now("utc").naive().to_iso8601_string(),
+            "dt": pendulum.now(timezone).naive().to_iso8601_string(),
             "tz": timezone,
         }
     else:

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -1,3 +1,4 @@
+import pendulum
 from typing import List, Dict, Any
 
 from prefect import api, models
@@ -94,6 +95,7 @@ async def set_flow_group_schedule(
     else:
         start_date = None
     for clock in clocks:
+        clock["start_date"] = start_date
         try:
             ClockSchema().load(clock)
         except:
@@ -101,7 +103,7 @@ async def set_flow_group_schedule(
     if not flow_group_id:
         raise ValueError("Invalid flow group ID")
     result = await models.FlowGroup.where(id=flow_group_id).update(
-        set=dict(schedule=dict(type="Schedule", clocks=clocks, start_date=start_date))
+        set=dict(schedule=dict(type="Schedule", clocks=clocks))
     )
 
     deleted_runs = await models.FlowRun.where(

--- a/src/prefect_server/graphql/flow_groups.py
+++ b/src/prefect_server/graphql/flow_groups.py
@@ -1,3 +1,4 @@
+import pendulum
 from typing import Any
 
 from graphql import GraphQLResolveInfo
@@ -58,8 +59,11 @@ async def resolve_set_flow_group_schedule(
         interval_clocks.append(clock)
 
     clocks = cron_clocks + interval_clocks
+
     result = await api.flow_groups.set_flow_group_schedule(
-        flow_group_id=input["flow_group_id"], clocks=clocks
+        flow_group_id=input["flow_group_id"],
+        clocks=clocks,
+        timezone=input.get("timezone"),
     )
     return {"success": result}
 

--- a/src/prefect_server/graphql/schema/flows.graphql
+++ b/src/prefect_server/graphql/schema/flows.graphql
@@ -168,6 +168,8 @@ input set_flow_group_schedule_input {
   cron_clocks: [cron_clock_input!]
   "A list of interval clocks for the schedule"
   interval_clocks: [interval_clock_input!]
+  "An optional timezone to use for the schedule
+  timezone: String
 }
 
 input cron_clock_input {

--- a/src/prefect_server/graphql/schema/flows.graphql
+++ b/src/prefect_server/graphql/schema/flows.graphql
@@ -168,7 +168,7 @@ input set_flow_group_schedule_input {
   cron_clocks: [cron_clock_input!]
   "A list of interval clocks for the schedule"
   interval_clocks: [interval_clock_input!]
-  "An optional timezone to use for the schedule
+  "An optional timezone to use for the schedule"
   timezone: String
 }
 

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -1,4 +1,5 @@
 import uuid
+import pendulum
 
 import pytest
 
@@ -214,6 +215,7 @@ class TestSetFlowGroupSchedule:
         flow_group = await models.FlowGroup.where(id=flow_group_id).first({"schedule"})
         schedule = schema.load(flow_group.schedule)
 
+        assert schedule.clocks[0].start_date <= pendulum.now("utc")
         assert schedule.clocks[0].start_date.timezone_name == "US/Pacific"
 
     async def test_setting_schedule_deletes_runs(self, flow_id, flow_group_id):

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -115,8 +115,9 @@ class TestSetFlowGroupSchedule:
                     "type": "CronClock",
                     "cron": "42 0 0 * * *",
                     "parameter_defaults": {"meep": "morp"},
+                    "start_date": None,
                 },
-                {"type": "CronClock", "cron": "43 0 0 * * *"},
+                {"type": "CronClock", "cron": "43 0 0 * * *", "start_date": None},
             ],
         }
 
@@ -144,8 +145,9 @@ class TestSetFlowGroupSchedule:
                     "type": "IntervalClock",
                     "interval": 4200000000,
                     "parameter_defaults": {"meep": "morp"},
+                    "start_date": None,
                 },
-                {"type": "IntervalClock", "interval": 4300000000},
+                {"type": "IntervalClock", "interval": 4300000000, "start_date": None},
             ],
         }
 
@@ -167,8 +169,8 @@ class TestSetFlowGroupSchedule:
         assert flow_group.schedule == {
             "type": "Schedule",
             "clocks": [
-                {"type": "CronClock", "cron": "42 0 0 * * *"},
-                {"type": "IntervalClock", "interval": 4200000000},
+                {"type": "CronClock", "cron": "42 0 0 * * *", "start_date": None},
+                {"type": "IntervalClock", "interval": 4200000000, "start_date": None},
             ],
         }
 

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -1,3 +1,4 @@
+import pendulum
 import pytest
 
 from prefect import models
@@ -170,6 +171,45 @@ class TestSetFlowGroupSchedule:
                 {"type": "IntervalClock", "interval": 4200000000},
             ],
         }
+
+    async def test_add_cron_and_interval_clocks_to_flow_group_schedule_with_timezone(
+        self, run_query, flow_group_id
+    ):
+        result = await run_query(
+            query=self.mutation,
+            variables=dict(
+                input=dict(
+                    flow_group_id=flow_group_id,
+                    cron_clocks=[{"cron": "42 0 0 * * *"}],
+                    interval_clocks=[{"interval": 4200}],
+                    timezone="US/Pacific",
+                )
+            ),
+        )
+        assert result.data.set_flow_group_schedule.success is True
+        flow_group = await models.FlowGroup.where(id=flow_group_id).first({"schedule"})
+
+        schedule = ScheduleSchema().load(flow_group.schedule)
+        assert len(schedule.clocks) == 2
+        assert all([c.start_date <= pendulum.now("utc") for c in schedule.clocks])
+        assert all(
+            [c.start_date.timezone_name == "US/Pacific" for c in schedule.clocks]
+        )
+
+    async def test_add_clocks_to_flow_group_schedule_with_timezone_raises_informative_error(
+        self, run_query, flow_group_id
+    ):
+        result = await run_query(
+            query=self.mutation,
+            variables=dict(
+                input=dict(
+                    flow_group_id=flow_group_id,
+                    cron_clocks=[{"cron": "42 0 0 * * *"}],
+                    timezone="US/Ocean",
+                )
+            ),
+        )
+        assert "Invalid timezone" in result.errors[0].message
 
     async def test_interval_clock_units(self, run_query, flow_group_id):
         await run_query(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR exposes a new `timezone` input to the `set_flow_group_schedule` GraphQL mutation.  Allowable timezones can be obtained via `pendulum.timezones` in Python (**cc:** @znicholasbrown / @ThatGalNatalie in case you need to audit this list and ensure the UI can serve these values appropriately).

For learning purposes, this PR demonstrates how the lifecycle of an API request works: clients send JSON payloads corresponding to GraphQL inputs.  The GraphQL resolver layer then manipulates / handles those, and passes them deeper into the API function layer.  Here, additional manipulation / validation may occur before placing the payloads into the database.  It is usually much easier for testing purposes to contain most of the logic / validation in the API layer.

In this case, the user-facing change is that a convenient / easy to understand `timezone` field is exposed.  Under the hood, within the API layer, we take this timezone and convert it into a `start_date` that can be interpreted by [the relevant Core Schedule serializers](https://github.com/PrefectHQ/prefect/blob/master/src/prefect/serialization/schedule.py) for the scheduler to consume / work with.  **NB:** timezones are specified via `start_date`s on schedules


## Importance
<!-- Why is this PR important? -->
Server-solution to https://github.com/PrefectHQ/ui/issues/423



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
