### PR TITLE
Use and display health url during apollo service startup

### DIFF
--- a/services/apollo/post-start.sh
+++ b/services/apollo/post-start.sh
@@ -2,7 +2,8 @@
 set -eu
 
 while true; do
-    curl -s $GRAPHQL_SERVICE_HOST:$GRAPHQL_SERVICE_PORT/health | grep "ok" \
+    echo "Checking GraphQL service at $PREFECT_API_HEALTH_URL ..."
+    curl -s $PREFECT_API_HEALTH_URL | grep "ok" \
         && echo "GraphQL service healthy!" && break
     sleep 1
 done


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Running `prefect server start` with `--graphql-port ####` fails because it sets `GRAPHQL_SERVICE_PORT` and the apollo service queries `$GRAPHQL_SERVICE_HOST:$GRAPHQL_SERVICE_PORT/health` which is in the docker network and should be the default port still. 

- Replaces this query with the health url that is available as an environment variable `PREFECT_API_HEALTH_URL`
- Adds a printout that it's doing a health check so it doesn't just silently hang

Also resolved by https://github.com/PrefectHQ/prefect/pull/3933 -- it looks like `core` was misusing the environment variable. That said, it seems weird that we are building the health url when it already is in the env so this PR may stand.


## Importance
<!-- Why is this PR important? -->

- Allows users to properly specify custom graphql ports
- Helps debug failing apollo startups


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
