### PR TITLE
Fix ORM tests and add `sum` aggregate 

### DIFF
--- a/changes/pr174.yaml
+++ b/changes/pr174.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add `sum` aggregate to ORM  - [#174](https://github.com/PrefectHQ/server/pull/174)"

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -568,7 +568,29 @@ class ModelQuery:
         result = await prefect.plugins.hasura.client.execute(query, as_box=False)
         return result["data"]["count"]["aggregate"]["count"]
 
-    async def max(self, columns) -> dict:
+    async def sum(self, columns:List[str]) -> dict:
+        """
+        Returns the sum of the requested columns
+
+        Args:
+
+        Returns:
+            - dict: the requested columns and corresponding minmums
+        """
+        agg_type = self.model.__root_fields__.get(
+            "select_aggregate", f"{self.model.__hasura_type__}_aggregate"
+        )
+        query = {
+            "query": {
+                with_args(f"sum_query: {agg_type}", {"where": self.where}): {
+                    "aggregate": {"sum": set(columns)}
+                }
+            }
+        }
+        result = await prefect.plugins.hasura.client.execute(query, as_box=False)
+        return result["data"]["sum_query"]["aggregate"]["sum"]
+
+    async def max(self, columns:List[str]) -> dict:
         """
         Returns the maximum value of the requested columns
 
@@ -590,7 +612,7 @@ class ModelQuery:
         result = await prefect.plugins.hasura.client.execute(query, as_box=False)
         return result["data"]["max_query"]["aggregate"]["max"]
 
-    async def min(self, columns) -> dict:
+    async def min(self, columns:List[str]) -> dict:
         """
         Returns the minimum value of the requested columns
 

--- a/src/prefect_server/database/orm.py
+++ b/src/prefect_server/database/orm.py
@@ -568,7 +568,7 @@ class ModelQuery:
         result = await prefect.plugins.hasura.client.execute(query, as_box=False)
         return result["data"]["count"]["aggregate"]["count"]
 
-    async def sum(self, columns:List[str]) -> dict:
+    async def sum(self, columns: List[str]) -> dict:
         """
         Returns the sum of the requested columns
 
@@ -590,7 +590,7 @@ class ModelQuery:
         result = await prefect.plugins.hasura.client.execute(query, as_box=False)
         return result["data"]["sum_query"]["aggregate"]["sum"]
 
-    async def max(self, columns:List[str]) -> dict:
+    async def max(self, columns: List[str]) -> dict:
         """
         Returns the maximum value of the requested columns
 
@@ -612,7 +612,7 @@ class ModelQuery:
         result = await prefect.plugins.hasura.client.execute(query, as_box=False)
         return result["data"]["max_query"]["aggregate"]["max"]
 
-    async def min(self, columns:List[str]) -> dict:
+    async def min(self, columns: List[str]) -> dict:
         """
         Returns the minimum value of the requested columns
 

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -479,6 +479,14 @@ class TestAggregates:
         result = await models.Flow.where().count(distinct_on=[EnumValue("name")])
         assert result == 2
 
+    async def test_sum(self):
+        result = await models.Flow.where().sum(["version"])
+        assert result['version'] == 6
+
+    async def test_sum_where(self):
+        result = await models.Flow.where({"name": {"_eq": "a"}}).sum(["version"])
+        assert result['version'] == 4
+
     async def test_max(self):
         result = await models.Flow.where().max(["version"])
         assert result['version'] == 3

--- a/tests/database/test_orm.py
+++ b/tests/database/test_orm.py
@@ -481,27 +481,27 @@ class TestAggregates:
 
     async def test_sum(self):
         result = await models.Flow.where().sum(["version"])
-        assert result['version'] == 6
+        assert result["version"] == 6
 
     async def test_sum_where(self):
         result = await models.Flow.where({"name": {"_eq": "a"}}).sum(["version"])
-        assert result['version'] == 4
+        assert result["version"] == 4
 
     async def test_max(self):
         result = await models.Flow.where().max(["version"])
-        assert result['version'] == 3
+        assert result["version"] == 3
 
     async def test_max_where(self):
         result = await models.Flow.where({"name": {"_eq": "b"}}).max(["version"])
-        assert result['version'] == 2
+        assert result["version"] == 2
 
     async def test_min(self):
         result = await models.Flow.where().min(["version"])
-        assert result['version'] == 1
+        assert result["version"] == 1
 
     async def test_min_where(self):
         result = await models.Flow.where({"name": {"_eq": "b"}}).min(["version"])
-        assert result['version'] == 2
+        assert result["version"] == 2
 
 
 class TestRunModels:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
- Fixes tests that were broken (they called a non-existent mock route, but because it was a mock... it didn't error)
- Adds a `sum` aggregate to the ORM:
```
await models.Flow.where().sum(['version'])
# yes it's a stupid example but it works
```
- Adds ORM tests for aggregates



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
