### PR TITLE
First class descriptions

### DIFF
--- a/changes/pr177.yaml
+++ b/changes/pr177.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add 'description' field for Flow Groups along with routes for updating - [#177](https://github.com/PrefectHQ/server/pull/177)"

--- a/services/hasura/migrations/versions/metadata-9116e81c6dc2.yaml
+++ b/services/hasura/migrations/versions/metadata-9116e81c6dc2.yaml
@@ -1,0 +1,272 @@
+functions:
+- function:
+    name: downstream_tasks
+    schema: utility
+- function:
+    name: upstream_tasks
+    schema: utility
+tables:
+- array_relationships:
+  - name: agents
+    using:
+      foreign_key_constraint_on:
+        column: agent_config_id
+        table:
+          name: agent
+          schema: public
+  table:
+    name: agent_config
+    schema: public
+- array_relationships:
+  - name: downstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: upstream_task_id
+        table:
+          name: edge
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          name: task_run
+          schema: public
+  - name: upstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: downstream_task_id
+        table:
+          name: edge
+          schema: public
+  object_relationships:
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  table:
+    name: task
+    schema: public
+- array_relationships:
+  - name: edges
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: edge
+          schema: public
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_run
+          schema: public
+  - name: tasks
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: task
+          schema: public
+  object_relationships:
+  - name: flow_group
+    using:
+      foreign_key_constraint_on: flow_group_id
+  - name: project
+    using:
+      foreign_key_constraint_on: project_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow
+    schema: public
+- array_relationships:
+  - name: flow_groups
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow_group
+          schema: public
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow
+          schema: public
+  - name: projects
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: project
+          schema: public
+  table:
+    name: tenant
+    schema: public
+- array_relationships:
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: agent_id
+        table:
+          name: flow_run
+          schema: public
+  object_relationships:
+  - name: agent_config
+    using:
+      foreign_key_constraint_on: agent_config_id
+  table:
+    name: agent
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: flow_group_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_group
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: project
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: flow_run_state
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: task_run
+          schema: public
+  object_relationships:
+  - name: agent
+    using:
+      foreign_key_constraint_on: agent_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_run
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: task_run_state
+          schema: public
+  object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  - name: task
+    using:
+      foreign_key_constraint_on: task_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: task_run
+    schema: public
+- object_relationships:
+  - name: downstream_task
+    using:
+      foreign_key_constraint_on: downstream_task_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+  table:
+    name: edge
+    schema: public
+- object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  table:
+    name: flow_run_state
+    schema: public
+- object_relationships:
+  - name: task
+    using:
+      manual_configuration:
+        column_mapping:
+          task_id: id
+        remote_table:
+          name: task
+          schema: public
+  table:
+    name: traversal
+    schema: utility
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_artifact
+    schema: public
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_state
+    schema: public
+- table:
+    name: cloud_hook
+    schema: public
+- table:
+    name: log
+    schema: public
+- table:
+    name: message
+    schema: public
+version: 2

--- a/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
+++ b/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
@@ -8,7 +8,6 @@ Create Date: 2021-01-20 13:22:30.242349
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 
 # revision identifiers, used by Alembic.
@@ -21,7 +20,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         "flow_group",
-        sa.Column("description", JSONB, nullable=True, server_default=None),
+        sa.Column("description", sa.String, nullable=True, server_default=None),
     )
 
 

--- a/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
+++ b/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
@@ -1,0 +1,28 @@
+"""
+Add description to flow group table
+
+Revision ID: 9116e81c6dc2
+Revises: 7ca57ea2fdff
+Create Date: 2021-01-20 13:22:30.242349
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = '9116e81c6dc2'
+down_revision = '7ca57ea2fdff'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow_group", sa.Column("description", JSONB, nullable=True, server_default=None)
+    )
+
+
+def downgrade():
+    op.drop_column("flow_group", "description")

--- a/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
+++ b/services/postgres/alembic/versions/2021-01-20T132230_add_description_to_flow_group_table.py
@@ -12,15 +12,16 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 
 # revision identifiers, used by Alembic.
-revision = '9116e81c6dc2'
-down_revision = '7ca57ea2fdff'
+revision = "9116e81c6dc2"
+down_revision = "7ca57ea2fdff"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     op.add_column(
-        "flow_group", sa.Column("description", JSONB, nullable=True, server_default=None)
+        "flow_group",
+        sa.Column("description", JSONB, nullable=True, server_default=None),
     )
 
 

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -182,7 +182,7 @@ async def set_flow_group_description(
 
     Args:
         - flow_group_id (str): the ID of the flow group to update
-        - description (dict, optional): A markdown-compatible description for this flow group.
+        - description (str, optional): A markdown-compatible description for this flow group.
             Providing `None` resets any previous flow group
             `description` setting.
 

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -173,6 +173,33 @@ async def set_flow_group_labels(flow_group_id: str, labels: List[str] = None) ->
     return bool(result.affected_rows)
 
 
+@register_api("flow_groups.set_flow_group_description")
+async def set_flow_group_description(
+    flow_group_id: str, description: str = None
+) -> bool:
+    """
+    Sets description for a flow group.
+
+    Args:
+        - flow_group_id (str): the ID of the flow group to update
+        - description (dict, optional): A markdown-compatible description for this flow group.
+            Providing `None` resets any previous flow group
+            `description` setting.
+
+    Returns:
+        - bool: whether setting `description` for the flow group was successful
+
+    Raises:
+        - ValueError: if flow group ID isn't provided
+    """
+    if not flow_group_id:
+        raise ValueError("Invalid flow group ID")
+    result = await models.FlowGroup.where(id=flow_group_id).update(
+        set=dict(description=description)
+    )
+    return bool(result.affected_rows)
+
+
 @register_api("flow_groups.set_flow_group_run_config")
 async def set_flow_group_run_config(
     flow_group_id: str, run_config: Dict[str, Any] = None

--- a/src/prefect_server/database/models.py
+++ b/src/prefect_server/database/models.py
@@ -307,6 +307,7 @@ class FlowGroup(HasuraModel):
     id: UUIDString = None
     created: datetime.datetime = None
     updated: datetime.datetime = None
+    description: str = None
     tenant_id: UUIDString = None
     name: str = None
     settings: dict = None

--- a/src/prefect_server/graphql/flow_groups.py
+++ b/src/prefect_server/graphql/flow_groups.py
@@ -17,6 +17,16 @@ async def resolve_set_flow_group_default_parameters(
     return {"success": result}
 
 
+@mutation.field("set_flow_group_description")
+async def resolve_set_flow_group_description(
+    obj: Any, info: GraphQLResolveInfo, input: dict
+) -> dict:
+    result = await api.flow_groups.set_flow_group_description(
+        flow_group_id=input["flow_group_id"], description=input.get("description")
+    )
+    return {"success": result}
+
+
 @mutation.field("set_flow_group_labels")
 async def resolve_set_flow_group_labels(
     obj: Any, info: GraphQLResolveInfo, input: dict

--- a/src/prefect_server/graphql/schema/flows.graphql
+++ b/src/prefect_server/graphql/schema/flows.graphql
@@ -161,7 +161,7 @@ input set_flow_group_description_input {
   "The ID of the flow group to update"
   flow_group_id: UUID!
   "Description to associate with the flow group"
-  description: JSON
+  description: String
 }
 
 input set_flow_group_run_config_input {

--- a/src/prefect_server/graphql/schema/flows.graphql
+++ b/src/prefect_server/graphql/schema/flows.graphql
@@ -39,6 +39,9 @@ extend type Mutation {
     input: enable_flow_lazarus_process_input!
   ): success_payload
 
+  "Set description for a flow group."
+  set_flow_group_description(input: set_flow_group_description_input!): success_payload
+
   "Set labels for a flow group."
   set_flow_group_labels(input: set_flow_group_labels_input!): success_payload
 
@@ -152,6 +155,13 @@ input set_flow_group_labels_input {
   flow_group_id: UUID!
   "Labels to associate with the flow group"
   labels: [String!]
+}
+
+input set_flow_group_description_input {
+  "The ID of the flow group to update"
+  flow_group_id: UUID!
+  "Description to associate with the flow group"
+  description: JSON
 }
 
 input set_flow_group_run_config_input {

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -121,6 +121,39 @@ class TestSetFlowGroupLabels:
             )
 
 
+class TestSetFlowGroupDescription:
+    @pytest.mark.parametrize(
+        "description", [None, "it does a thing.", "# TITLE\n it does *MANY* things"]
+    )
+    async def test_set_flow_group_description(self, flow_group_id, description):
+        flow_group = await models.FlowGroup.where(id=flow_group_id).first(
+            {"description"}
+        )
+        assert flow_group.description is None
+
+        success = await api.flow_groups.set_flow_group_description(
+            flow_group_id=flow_group_id, description=description
+        )
+        assert success is True
+
+        flow_group = await models.FlowGroup.where(id=flow_group_id).first(
+            {"description"}
+        )
+        assert flow_group.description == description
+
+    async def test_set_flow_group_description_for_invalid_flow_group(self):
+        success = await api.flow_groups.set_flow_group_description(
+            flow_group_id=str(uuid.uuid4()), description=None
+        )
+        assert success is False
+
+    async def test_set_flow_group_description_for_none_flow_group(self):
+        with pytest.raises(ValueError, match="Invalid flow group ID"):
+            await api.flow_groups.set_flow_group_description(
+                flow_group_id=None, description=None
+            )
+
+
 class TestSetFlowGroupRunConfig:
     @pytest.mark.parametrize(
         "run_config", [None, {"type": "UniversalRun", "labels": ["a"]}]

--- a/tests/graphql/test_flow_groups.py
+++ b/tests/graphql/test_flow_groups.py
@@ -79,6 +79,34 @@ class TestSetFlowGroupRunConfig:
         assert flow_group.run_config == run_config
 
 
+class TestSetFlowGroupDescription:
+    mutation = """
+        mutation($input: set_flow_group_description_input!) {
+            set_flow_group_description(input: $input) {
+                success
+            }
+        }
+    """
+
+    @pytest.mark.parametrize(
+        "description", [None, "it does a thing.", "# TITLE\n it does *MANY* things"]
+    )
+    async def test_set_flow_group_description(
+        self, run_query, flow_group_id, description
+    ):
+        result = await run_query(
+            query=self.mutation,
+            variables=dict(
+                input=dict(flow_group_id=flow_group_id, description=description)
+            ),
+        )
+        assert result.data.set_flow_group_description.success is True
+        flow_group = await models.FlowGroup.where(id=flow_group_id).first(
+            {"description"}
+        )
+        assert flow_group.description == description
+
+
 class TestSetFlowGroupSchedule:
     mutation = """
         mutation($input: set_flow_group_schedule_input!) {


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR adds formal support for Flow Group descriptions that can be edited via API.  In particular, we now have the following ways of creating and managing descriptions for flows and flow groups:
- passing a `description` when calling `mutation{create_flow}` (this has been supported for a long time -- *cc* @jcrist in case you wanted to begin using this in Core)
- calling the `set_flow_group_description` mutation (this is what this PR adds)

Note that this flow group field will be treated _slightly_ differently from other flow group fields in that the description will not be an override.  Instead, it will be editable and persistent, but individual versions may still have their own descriptions displayed (but note that they won't be editable).

All descriptions will support markdown formatting when displayed.

**cc:** @zhen0 

## Importance
<!-- Why is this PR important? -->
This will enable a more fully featured UI experience for flows, especially for those that 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
