### PR TITLE
Update tag versioning scheme to be PEP 440 compliant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
+              only: /(2\d{3}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])).*/
 
       - docker/publish:
           docker-password: DOCKER_HUB_PW
@@ -234,4 +234,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
+              only: /(2\d{3}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])).*/

--- a/changes/pr178.yaml
+++ b/changes/pr178.yaml
@@ -1,0 +1,2 @@
+breaking:
+  - "Move to `YYYY.MM.DD` versioning scheme away from `YYYY-MM-DD` - [#178](https://github.com/PrefectHQ/server/pull/178)"


### PR DESCRIPTION
We began seeing some build errors recently (interestingly enough, they appeared to be non-deterministic) because Prefect Server's versioning scheme was not [PEP 440](https://www.python.org/dev/peps/pep-0440) compliant, resulting in invalid wheels.

This PR updates our jobs to detect versions based on `YYYY.MM.DD` instead of `YYYY-MM-DD`