### PR TITLE
Helm: Optionally create a tenant

### DIFF
--- a/changes/pr183.yaml
+++ b/changes/pr183.yaml
@@ -1,0 +1,6 @@
+feature:
+  - "Helm: Optionally create the default tenant before running Agent - [#183](https://github.com/PrefectHQ/server/pull/183)"
+
+contributor:
+    - "[Michał @ DataRevenue](https://github.com/michcio1234)"
+

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -39,11 +39,14 @@ Export the password as the error asks then set it within the subchart using `--s
 See comments in `values.yaml`.
 
 ### Tenant
+A tenant is needed for the server API to be operational.
+If there is no tenant in the database, the UI dashboard will fail to display and agents will error.
 
-To automatically create a default tenant, use the flag `--set jobs.createTenant.enabled=true`. 
-A Tenant is needed for the dashboard and the agent to run properly.
+To automatically create a default tenant, use the flag `--set jobs.createTenant.enabled=true`.
 
-Alternatively, you can create a tenant manually. See [Troubleshooting](#troubleshooting) section.
+To create the tenant manually when your chart is already installed, 
+run `prefect backend server && prefect server create-tenant --name default --slug default` to create a default tenant.
+Check out [Connecting to your Server](#connecting-to-your-server) to connect your local `prefect` to your server before creating the tenant.
 
 ### KubernetesAgent
 
@@ -103,12 +106,7 @@ Alternatively, you can port-forward the apollo service to your localhost
 
 If you go to the 'Home' page, it will likely direct you to create a tenant. Without a tenant, the dashboard cannot display.
 
-See [Tenant](#tenant) section to learn how to automatically create the default tenant during chart
-installation.
-
-To create the tenant manually when your chart is already installed, 
-run `prefect backend server && prefect server create-tenant --name default --slug default` to create a default tenant.
-Check out [Connecting to your Server](#connecting-to-your-server) to connect your local `prefect` to your server before creating the tenant.
+See the [Tenant](#tenant) section to learn how to create a default tenant.
 
 ### The UI loads but cannot connect to the API
 

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -38,6 +38,12 @@ Export the password as the error asks then set it within the subchart using `--s
 
 See comments in `values.yaml`.
 
+### Tenant
+
+To automatically create a default tenant, use the flag `--set jobs.createTenant.enabled=true`. 
+A Tenant is needed for the dashboard and the agent to run properly.
+
+Alternatively, you can create a tenant manually. See [Troubleshooting](#troubleshooting) section.
 
 ### KubernetesAgent
 
@@ -95,9 +101,13 @@ Alternatively, you can port-forward the apollo service to your localhost
 
 ### The UI loads but the dashboard is blank
 
-If you go to the 'Home' page it will likely direct you to create a tenant. Without a tenant, the dashboard cannot display.
-Run `prefect backend server && prefect server create-tenant --name default --slug default` to create a default tenant.
+If you go to the 'Home' page, it will likely direct you to create a tenant. Without a tenant, the dashboard cannot display.
 
+See [Tenant](#tenant) section to learn how to automatically create the default tenant during chart
+installation.
+
+To create the tenant manually when your chart is already installed, 
+run `prefect backend server && prefect server create-tenant --name default --slug default` to create a default tenant.
 Check out [Connecting to your Server](#connecting-to-your-server) to connect your local `prefect` to your server before creating the tenant.
 
 ### The UI loads but cannot connect to the API

--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -41,20 +41,15 @@
 
 {{- end }}
 
-#3 The UI has been configured to point to '{{ .Values.ui.apolloApiUrl }}' by default. 
+#3 The UI has been configured to point to '{{ .Values.ui.apolloApiUrl }}' by default.
   - The API location you retrieved in #2 should match this url
   - The default can be changed in the helm deployment at 'ui.apolloApiUrl' if it is incorrect
   - The location can also be changed within the UI itself per user
   - The API must be accessible from the the user's machine for the UI to work
 
-{{- if .Values.jobs.createTenant.enabled }}
+{{- if not .Values.jobs.createTenant.enabled }}
 
-#4 The `{{ .Values.jobs.createTenant.tenant.name }}` tenant was created.
-   The dashboard and the Agent (if enabled) should become functional without any further action.
-
-{{- else }}
-
-#4 You or your admin will likely have to create a tenant before the dashboard in the UI will work. 
+#4 You or your admin will likely have to create a tenant before the dashboard in the UI will work.
    The UI home page should have a 'Create tenant' tab to walk you through this process.
 
 {{- end }}

--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -47,5 +47,14 @@
   - The location can also be changed within the UI itself per user
   - The API must be accessible from the the user's machine for the UI to work
 
+{{- if .Values.jobs.createTenant.enabled }}
+
+#4 The `{{ .Values.jobs.createTenant.tenant.name }}` tenant was created.
+   The dashboard and the Agent (if enabled) should become functional without any further action.
+
+{{- else }}
+
 #4 You or your admin will likely have to create a tenant before the dashboard in the UI will work. 
    The UI home page should have a 'Create tenant' tab to walk you through this process.
+
+{{- end }}

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -30,25 +30,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.agent.createTenant }}
-      initContainers:
-      - name: create-tenant
-        {{- with .Values.agent.podSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default .Values.prefectVersionTag }}"
-        imagePullPolicy: {{ .Values.agent.image.pullPolicy  }}
-        command:
-          - bash
-          - "-c"
-          - "prefect server create-tenant --name default --slug default || [[ $(prefect server create-tenant --name default --slug default  2>&1) =~ 'Uniqueness violation' ]]"
-        env:
-          - name: PREFECT__CLOUD__API
-            value: {{ include "prefect-server.apollo-api-url" . }}
-          - name: PREFECT__BACKEND
-            value: server
-      {{- end }}
       containers:
       - name: agent
         {{- with .Values.agent.podSecurityContext }}

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -30,6 +30,25 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.agent.createTenant }}
+      initContainers:
+      - name: create-tenant
+        {{- with .Values.agent.podSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default .Values.prefectVersionTag }}"
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy  }}
+        command:
+          - bash
+          - "-c"
+          - "prefect server create-tenant --name default --slug default || [[ $(prefect server create-tenant --name default --slug default  2>&1) =~ 'Uniqueness violation' ]]"
+        env:
+          - name: PREFECT__CLOUD__API
+            value: {{ include "prefect-server.apollo-api-url" . }}
+          - name: PREFECT__BACKEND
+            value: server
+      {{- end }}
       containers:
       - name: agent
         {{- with .Values.agent.podSecurityContext }}

--- a/helm/prefect-server/templates/jobs/create_tenant.yaml
+++ b/helm/prefect-server/templates/jobs/create_tenant.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.jobs.createTenant.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "prefect-server.nameField" (merge (dict "component" "create-tenant-job") .) }}
+  labels:
+    {{- include "prefect-server.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: create-tenant-job
+  annotations:
+    {{- merge .Values.jobs.createTenant.annotations .Values.annotations | toYaml | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "prefect-server.matchLabels" . | nindent 8 }}
+        app.kubernetes.io/component: create-tenant-job
+    spec:
+      imagePullSecrets: {{ concat .Values.jobs.createTenant.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+      {{- with .Values.jobs.createTenant.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: create-tenant
+          {{- with .Values.jobs.createTenant.securityContext -}}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.jobs.createTenant.image.name }}:{{ .Values.jobs.createTenant.image.tag |  default .Values.prefectVersionTag }}"
+          imagePullPolicy: {{ .Values.jobs.createTenant.image.pullPolicy  }}
+          command:
+            - "bash"
+            - "-c"
+            - "prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }} || [[ $(prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }}  2>&1) =~ 'Uniqueness violation' ]]"
+          env:
+            - name: PREFECT__CLOUD__API
+              value: {{ include "prefect-server.apollo-api-url" . }}
+            - name: PREFECT__BACKEND
+              value: server
+      restartPolicy: OnFailure
+  backoffLimit: {{ .Values.jobs.createTenant.backoffLimit }}
+{{- end }}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -264,6 +264,9 @@ agent:
   # be associated with the agent
   prefectLabels: []
 
+  # whether to include an init container which will create a default tenant prior to starting the agent
+  createTenant: false
+
   # image configures the container image for the agent deployment
   image:
     name: prefecthq/prefect

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -264,9 +264,6 @@ agent:
   # be associated with the agent
   prefectLabels: []
 
-  # whether to include an init container which will create a default tenant prior to starting the agent
-  createTenant: false
-
   # image configures the container image for the agent deployment
   image:
     name: prefecthq/prefect
@@ -317,3 +314,33 @@ serviceAccount:
   # If not set and create is true, a name is generated using the
   # prefect-server.nameField template
   name: null
+
+
+# jobs contain one-time job definitions
+jobs:
+
+  # create a tenant so that Agent and UI are immediately usable after installation
+  createTenant:
+    enabled: false
+
+    # tenant sets the details of the created tenant
+    tenant:
+      name: default
+      slug: default
+
+    # image configures the container image for the job
+    image:
+      name: prefecthq/prefect
+      tag: null
+      pullPolicy: Always
+      pullSecrets: []
+
+    labels: {}
+    annotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    # backoffLimit configures the number of retries; needed to wait for the server to become available
+    backoffLimit: 10


### PR DESCRIPTION
## Summary
In Helm chart, add an option to automatically create a default tenant.

## Importance
It's a bit cumbersome to configure a local CLI client to connect to a custom Kubernetes deployment, especially when there are no flags like `--host` and `--port`. For an inexperienced user, like me, it was far from obvious how to do it. Yet this is the only way I found in the docs to create a tenant. I thought it would be good if the tenant was added automatically.

## Misc
I couldn't find a way of checking whether a tenant is already created, that's why I fell back to just trying to create it, and checking for a particular error to see if it's already there. I know it's ugly.

I am just beginning getting to know Prefect. I am sure that there is a prettier way of achieving what I've done here. Yet this is what I was able to come up with and I suppose it would be helpful for others until someone does it in a more elegant way.

## Checklist
This PR:

- [x] adds new tests (doesn't apply, I guess, but I tested it as well as I could locally)
- [x] adds a change file in the `changes/` directory (if appropriate)
