### PR TITLE
Better archiving experience

### DIFF
--- a/changes/pr185.yaml
+++ b/changes/pr185.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Cancel ad-hoc created flow runs instead of deleting them when archiving a flow - [#185](https://github.com/PrefectHQ/server/pull/185)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -372,8 +372,10 @@ async def archive_flow(flow_id: str) -> bool:
         }
     ).get({"id"})
     msg = f"Flow {flow_id} was archived."
+    tasks = []
     for flow_run in fr_ids:
-        await api.states.cancel_flow_run(flow_run.id, state_message=msg)
+        tasks.append(api.states.cancel_flow_run(flow_run.id, state_message=msg))
+    await asyncio.gather(*tasks)
     return True
 
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -332,7 +332,8 @@ async def archive_flow(flow_id: str) -> bool:
     Archives a flow.
 
     Archiving a flow prevents it from scheduling new runs. It also:
-        - deletes any currently scheduled runs
+        - deletes any currently auto-scheduled runs
+        - cancels any ad-hoc created scheduled runs
         - resets the "last scheduled run time" of any schedules
 
     Args:
@@ -355,9 +356,24 @@ async def archive_flow(flow_id: str) -> bool:
 
     # delete scheduled flow runs
     await models.FlowRun.where(
-        {"flow_id": {"_eq": flow_id}, "state": {"_eq": "Scheduled"}}
+        {
+            "flow_id": {"_eq": flow_id},
+            "state": {"_eq": "Scheduled"},
+            "auto_scheduled": {"_eq": True},
+        }
     ).delete()
 
+    # cancel adhoc scheduled flow runs
+    fr_ids = await models.FlowRun.where(
+        {
+            "flow_id": {"_eq": flow_id},
+            "state": {"_eq": "Scheduled"},
+            "auto_scheduled": {"_eq": False},
+        }
+    ).get({"id"})
+    msg = f"Flow {flow_id} was archived."
+    for flow_run in fr_ids:
+        await api.states.cancel_flow_run(flow_run.id, state_message=msg)
     return True
 
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import hashlib
 import json
@@ -372,10 +373,12 @@ async def archive_flow(flow_id: str) -> bool:
         }
     ).get({"id"})
     msg = f"Flow {flow_id} was archived."
-    tasks = []
-    for flow_run in fr_ids:
-        tasks.append(api.states.cancel_flow_run(flow_run.id, state_message=msg))
-    await asyncio.gather(*tasks)
+    await asyncio.gather(
+        *[
+            api.states.cancel_flow_run(flow_run.id, state_message=msg)
+            for flow_run in fr_ids
+        ]
+    )
     return True
 
 

--- a/src/prefect_server/api/states.py
+++ b/src/prefect_server/api/states.py
@@ -207,7 +207,9 @@ async def set_task_run_state(
 
 
 @register_api("states.cancel_flow_run")
-async def cancel_flow_run(flow_run_id: str) -> models.FlowRun:
+async def cancel_flow_run(
+    flow_run_id: str, state_message: str = None
+) -> models.FlowRun:
     """
     Cancel a flow run.
 
@@ -231,7 +233,7 @@ async def cancel_flow_run(flow_run_id: str) -> models.FlowRun:
         return flow_run
     else:
         if state.is_running():
-            state = Cancelling("Flow run is cancelling")
+            state = Cancelling(state_message or "Flow run is cancelling")
         else:
-            state = Cancelled("Flow run is cancelled")
+            state = Cancelled(state_message or "Flow run is cancelled")
         return await set_flow_run_state(flow_run_id=flow_run_id, state=state)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Currently, whenever a flow is archived we _delete_ all outstanding runs for that flow that are still in a `Scheduled` state (because they can't run).  This works well for auto scheduled runs; however, users who create ad-hoc runs for a flow that maybe take a while to begin (due to concurrency limits, or maybe an agent malfunction) might register a new version in the meantime.  In this situation, the deletion of these runs can be very mysterious and unexpected.  @znicholasbrown noted that we could instead _cancel_ these runs so that there is a record of what happened.


## Importance
<!-- Why is this PR important? -->
More transparent UX.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
