### PR TITLE
Uniformize errors

### DIFF
--- a/changes/pr189.yaml
+++ b/changes/pr189.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Capture all 'connect' errors and uniformize into DB query errors - [#189](https://github.com/PrefectHQ/server/pull/189)"

--- a/src/prefect_server/utilities/graphql.py
+++ b/src/prefect_server/utilities/graphql.py
@@ -53,13 +53,18 @@ class GraphQLClient:
         if prefect_server.config.debug:
             ariadne.gql(query)
 
-        # timeout of 30 seconds
-        response = await httpx_client.post(
-            self.url,
-            json=dict(query=query, variables=variables or {}),
-            headers=headers or self.headers,
-            timeout=30,
-        )
+        try:
+            # timeout of 30 seconds
+            response = await httpx_client.post(
+                self.url,
+                json=dict(query=query, variables=variables or {}),
+                headers=headers or self.headers,
+                timeout=30,
+            )
+        except Exception as exc:
+            if "connect" in str(exc).lower():
+                raise ValueError("database query error")
+            raise
         try:
             result = response.json()
         except json.decoder.JSONDecodeError as exc:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR captures all errors from GraphQL -> Hasura that have "connect" in the exception and converts them into a uniform "database query error".  Other clients handle these errors specially, so we can rely on client-side behavior here instead of rolling custom retries in this code path.  In looking at this it does seem we have some tech debt in error handling around here that we might want to revisit - low priority though.

**cc:** @mashun4ek 


## Importance
<!-- Why is this PR important? -->
Helps with some fault tolerance in rare cases by relying on other clients' handling of "database query error"s.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
