### PR TITLE
Add tini to graphql and apollo containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.label-schema.version=${PREFECT_SERVER_VERSION}
 LABEL org.label-schema.build-date=${RELEASE_TIMESTAMP}
 
 RUN apt update && \
-    apt install -y gcc git curl && \
+    apt install -y gcc git curl tini && \
     mkdir /root/.prefect/ && \
     pip install --no-cache-dir git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION} && \
     apt remove -y git && \
@@ -42,4 +42,5 @@ RUN \
 
 WORKDIR /prefect-server
 
+ENTRYPOINT ["tini", "-g", "--"]
 CMD python

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# TODO: Install tini (once we move to a newer version of debian, apt-get install will work)
+
 WORKDIR /apollo
 COPY . .
 
@@ -32,4 +34,5 @@ RUN npm ci && \
     npm run build && \
     chmod +x post-start.sh
 
+ENTRYPOINT ["tini", "-g", "--"]
 CMD ["npm", "run", "serve"]


### PR DESCRIPTION
The healthchecks in these containers were leading to zombie processes,
since there was no init process around to reap them. For some reason the
other containers don't have this problem (something else must be reaping
the health check processes).

This PR is only half done, still needs to be added to apollo. My
internet/electricity is not consistent enough right now to finish this
up, would be good if someone else could.

Fixes https://github.com/PrefectHQ/prefect/issues/4114