### PR TITLE
Add tini to graphql and apollo containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.label-schema.version=${PREFECT_SERVER_VERSION}
 LABEL org.label-schema.build-date=${RELEASE_TIMESTAMP}
 
 RUN apt update && \
-    apt install -y gcc git curl && \
+    apt install -y gcc git curl tini && \
     mkdir /root/.prefect/ && \
     pip install --no-cache-dir git+https://github.com/PrefectHQ/prefect.git@${PREFECT_VERSION} && \
     apt remove -y git && \
@@ -42,4 +42,5 @@ RUN \
 
 WORKDIR /prefect-server
 
+ENTRYPOINT ["tini", "-g", "--"]
 CMD python

--- a/changes/pr191.yaml
+++ b/changes/pr191.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Add `tini` init process to GraphQL and Apollo containers to reap zombies - [#191](https://github.com/PrefectHQ/server/pull/191)"

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -12,6 +12,10 @@ ENV PREFECT_SERVER_VERSION=${PREFECT_SERVER_VERSION:-master}
 ARG RELEASE_TIMESTAMP
 ENV RELEASE_TIMESTAMP=$RELEASE_TIMESTAMP
 
+# Architecture to support. Necessary for a working tini entrypoint on non-x86/64 builds
+ARG ARCH
+ENV ARCH=${ARCH:-amd64}
+
 # Image Labels
 LABEL maintainer="help@prefect.io"
 LABEL org.label-schema.schema-version = "1.0"
@@ -21,20 +25,16 @@ LABEL org.label-schema.version=${PREFECT_VERSION}
 LABEL org.label-schema.build-date=${RELEASE_TIMESTAMP}
 
 RUN apt-get update \
- && apt-get install curl gpg dirmngr --no-install-recommends -y \
+ && apt-get install curl --no-install-recommends -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# Install TINI per
-# - https://github.com/krallin/tini#signed-binaries
-# - https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9
-# Once we upgrade to a newer version of Debian (Buster+), we can just `apt-get install tini` and remove gpg/dirmngr
+# Install tini with checksum verification
+# Once we upgrade to a newer version of Debian (Buster+), we can just `apt-get install tini`
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-RUN mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini-${ARCH}
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH}.sha256sum /tini.sha256sum
+RUN echo "$(cat tini.sha256sum)" | sha256sum -c && mv /tini-${ARCH} /tini
 RUN chmod +x /tini
 
 WORKDIR /apollo

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# TODO: Install tini (once we move to a newer version of debian, apt-get install will work)
+
 WORKDIR /apollo
 COPY . .
 
@@ -32,4 +34,5 @@ RUN npm ci && \
     npm run build && \
     chmod +x post-start.sh
 
+ENTRYPOINT ["tini", "-g", "--"]
 CMD ["npm", "run", "serve"]

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -21,11 +21,21 @@ LABEL org.label-schema.version=${PREFECT_VERSION}
 LABEL org.label-schema.build-date=${RELEASE_TIMESTAMP}
 
 RUN apt-get update \
- && apt-get install curl --no-install-recommends -y \
+ && apt-get install curl gpg dirmngr --no-install-recommends -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# TODO: Install tini (once we move to a newer version of debian, apt-get install will work)
+# Install TINI per
+# - https://github.com/krallin/tini#signed-binaries
+# - https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9
+# Once we upgrade to a newer version of Debian (Buster+), we can just `apt-get install tini` and remove gpg/dirmngr
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+RUN mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+ && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+ && gpg --batch --verify /tini.asc /tini
+RUN chmod +x /tini
 
 WORKDIR /apollo
 COPY . .
@@ -34,5 +44,5 @@ RUN npm ci && \
     npm run build && \
     chmod +x post-start.sh
 
-ENTRYPOINT ["tini", "-g", "--"]
+#ENTRYPOINT ["/tini", "-g", "--"]
 CMD ["npm", "run", "serve"]

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -44,5 +44,5 @@ RUN npm ci && \
     npm run build && \
     chmod +x post-start.sh
 
-#ENTRYPOINT ["/tini", "-g", "--"]
+ENTRYPOINT ["/tini", "-g", "--"]
 CMD ["npm", "run", "serve"]

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -34,8 +34,9 @@ RUN apt-get update \
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini-${ARCH}
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH}.sha256sum /tini.sha256sum
-RUN echo "$(cat tini.sha256sum)" | sha256sum -c && mv /tini-${ARCH} /tini
-RUN chmod +x /tini
+RUN echo "$(cat tini.sha256sum)" | sha256sum -c \
+ && mv /tini-${ARCH} /tini \
+ && chmod +x /tini
 
 WORKDIR /apollo
 COPY . .


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

Finishes #190.

--------

## Summary
<!-- A sentence summarizing the PR -->

Installs `tini` and uses as an entrypoint to graphql/apollo containers to reap zombie processes.

## Notes for review

- Uses sha256 instead of gpg  for checksum verification (both are recommended checks but sha256 is significantly lighter with a 2x faster image build time)


- Fails to run when build on an M1 machine with
```
❯ docker run -it 932c6511928bbb40c364b9a414333e802c9fe8a9edd76dfb7d58cbf59df2c613
/lib64/ld-linux-x86-64.so.2: No such file or directory
```
I've added an `ARCH` flag so you can `docker build . --build-arg ARCH=arm64` for development builds. I presume that once we use apt it'll just grab the correct binary automatically.

## Importance
<!-- Why is this PR important? -->

Fixes PrefectHQ/prefect#4114


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
