### PR TITLE
Explicitly use debian buster for apollo/server images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.0.0-experimental
 
 ARG PYTHON_VERSION=${PYTHON_VERSION:-3.7}
-FROM python:${PYTHON_VERSION}-slim
+FROM python:${PYTHON_VERSION}-slim-buster
 
 # Prefect Version, default to MASTER
 ARG PREFECT_SERVER_VERSION

--- a/changes/pr198.yaml
+++ b/changes/pr198.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Upgrade apollo base image to debian-buster - [#198](https://github.com/PrefectHQ/server/pull/198)"

--- a/services/apollo/Dockerfile
+++ b/services/apollo/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=${NODE_VERSION:-14.15.1}
-FROM node:${NODE_VERSION}-slim
+FROM node:${NODE_VERSION}-buster-slim
 
 # Prefect Version, default to MASTER
 ARG PREFECT_VERSION


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

- Upgrades the `apollo` image to use `buster` instead of `stretch` Debian. 
- Changes the `server` image to explicitly use `buster` but should not change anything as it was implicit before

## Importance
<!-- Why is this PR important? -->

- Consistent base OS
- Security patches (see #198) 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
