### PR TITLE
Fix execution of create-tenant-job for custom Apollo ports

### DIFF
--- a/changes/pr200.yaml
+++ b/changes/pr200.yaml
@@ -1,0 +1,7 @@
+fix:
+  - "Fixed the execution of the `create-tenant-job` in the Helm charts to allow
+  for custom Apollo ports -
+  [#200](https://github.com/PrefectHQ/server/pull/200)"
+
+contributor:
+  - "[Jay Vercellone](https://github.com/jverce)"

--- a/changes/pr201.yaml
+++ b/changes/pr201.yaml
@@ -1,7 +1,7 @@
 fix:
   - "Fixed the execution of the `create-tenant-job` in the Helm charts to allow
   for custom Apollo ports -
-  [#200](https://github.com/PrefectHQ/server/pull/200)"
+  [#201](https://github.com/PrefectHQ/server/pull/201)"
 
 contributor:
   - "[Jay Vercellone](https://github.com/jverce)"

--- a/helm/prefect-server/templates/apollo/_helpers.tpl
+++ b/helm/prefect-server/templates/apollo/_helpers.tpl
@@ -15,7 +15,7 @@
 */}}
 {{- define "prefect-server.apollo-api-url" -}}
 {{- $host := include "prefect-server.apollo-hostname" . -}}
-{{- $port := "4200" -}}
-{{ printf "http://%s:%s/graphql/" $host $port }}
+{{- $port := (.Values.apollo.service.port | default 4200) -}}
+{{ printf "http://%s:%v/graphql" $host $port }}
 {{- end -}}
 

--- a/helm/prefect-server/templates/jobs/create_tenant.yaml
+++ b/helm/prefect-server/templates/jobs/create_tenant.yaml
@@ -33,7 +33,7 @@ spec:
             - "-c"
             - "prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }} || [[ $(prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }}  2>&1) =~ 'Uniqueness violation' ]]"
           env:
-            - name: PREFECT__CLOUD__API
+            - name: PREFECT__CLOUD__GRAPHQL
               value: {{ include "prefect-server.apollo-api-url" . }}
             - name: PREFECT__BACKEND
               value: server


### PR DESCRIPTION
* Change the `prefect-server.apollo-api-url` template to use the port of
  the Apollo service
* Set the `PREFECT__CLOUD__GRAPHQL` env variable of the
  `create-tenant-job` Job to avoid double concatenation of the
  `/graphql` path when calling the Apollo API

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Fixed the execution of the `create-tenant-job` in the Helm charts to allow for custom Apollo ports

## Importance
Without this PR, every time a user of the Prefect server Helm chart uses a port for the Apollo service different than the default one (i.e. 4200), and if they set the `jobs.createTenant.enabled` value to `true`, the associated `create-tenant-job` Job will fail with a message similar to this one:
```
requests.exceptions.ConnectTimeout: HTTPConnectionPool(host='prefect-server-apollo.prefect-namespace', port=4200): Max retries exceeded with url: /graphql//graphql (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7fb28e69e050>, 'Connection to prefect-server-apollo.prefect-namespace timed out. (connect timeout=15)'))
```

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
