### PR TITLE
Improve `delete_flow_run` performance by avoiding slow deletion triggers

### DIFF
--- a/changes/pr202.yaml
+++ b/changes/pr202.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Improve `delete_flow_run` performance by avoiding slow deletion triggers - [#202](https://github.com/PrefectHQ/server/pull/202)"

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -116,7 +116,7 @@ async def set_flow_group_schedule(
         }
     ).get({"id"})
     await asyncio.gather(
-        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
+        *[api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return bool(result.affected_rows)
@@ -151,7 +151,7 @@ async def delete_flow_group_schedule(flow_group_id: str) -> bool:
         }
     ).get({"id"})
     await asyncio.gather(
-        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
+        *[api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return bool(result.affected_rows)

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -106,13 +106,20 @@ async def set_flow_group_schedule(
         set=dict(schedule=dict(type="Schedule", clocks=clocks))
     )
 
-    deleted_runs = await models.FlowRun.where(
+    # Delete all auto-scheduled runs
+    runs_to_delete = await models.FlowRun.where(
         {
             "flow": {"flow_group_id": {"_eq": flow_group_id}},
             "state": {"_eq": "Scheduled"},
             "auto_scheduled": {"_eq": True},
         }
-    ).delete()
+    ).get({"id"})
+    await asyncio.gather(
+        *[
+            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
+        ]
+    )
+
     return bool(result.affected_rows)
 
 
@@ -136,13 +143,19 @@ async def delete_flow_group_schedule(flow_group_id: str) -> bool:
         set=dict(schedule=None)
     )
 
-    deleted_runs = await models.FlowRun.where(
+    # Delete all auto-scheduled runs
+    runs_to_delete = await models.FlowRun.where(
         {
             "flow": {"flow_group_id": {"_eq": flow_group_id}},
             "state": {"_eq": "Scheduled"},
             "auto_scheduled": {"_eq": True},
         }
-    ).delete()
+    ).get({"id"})
+    await asyncio.gather(
+        *[
+            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
+        ]
+    )
 
     return bool(result.affected_rows)
 

--- a/src/prefect_server/api/flow_groups.py
+++ b/src/prefect_server/api/flow_groups.py
@@ -1,4 +1,5 @@
 import pendulum
+import asyncio
 from typing import List, Dict, Any
 
 from prefect import api, models
@@ -115,9 +116,7 @@ async def set_flow_group_schedule(
         }
     ).get({"id"})
     await asyncio.gather(
-        *[
-            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
-        ]
+        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return bool(result.affected_rows)
@@ -152,9 +151,7 @@ async def delete_flow_group_schedule(flow_group_id: str) -> bool:
         }
     ).get({"id"})
     await asyncio.gather(
-        *[
-            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
-        ]
+        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return bool(result.affected_rows)

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -512,7 +512,7 @@ async def set_schedule_inactive(flow_id: str) -> bool:
         return False
 
     # Delete all auto-scheduled runs
-    run_to_delete = await models.FlowRun.where(
+    runs_to_delete = await models.FlowRun.where(
         {
             "flow_id": {"_eq": flow_id},
             "state": {"_eq": "Scheduled"},
@@ -520,9 +520,7 @@ async def set_schedule_inactive(flow_id: str) -> bool:
         }
     ).get({"id"})
     await asyncio.gather(
-        *[
-            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
-        ]
+        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return True

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -520,7 +520,7 @@ async def set_schedule_inactive(flow_id: str) -> bool:
         }
     ).get({"id"})
     await asyncio.gather(
-        *[await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
+        *[api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
     )
 
     return True

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -511,13 +511,19 @@ async def set_schedule_inactive(flow_id: str) -> bool:
     if not result.affected_rows:
         return False
 
-    deleted_runs = await models.FlowRun.where(
+    # Delete all auto-scheduled runs
+    run_to_delete = await models.FlowRun.where(
         {
             "flow_id": {"_eq": flow_id},
             "state": {"_eq": "Scheduled"},
             "auto_scheduled": {"_eq": True},
         }
-    ).delete()
+    ).get({"id"})
+    await asyncio.gather(
+        *[
+            await api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete
+        ]
+    )
 
     return True
 

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -421,7 +421,7 @@ async def delete_flow_run(flow_run_id: str) -> bool:
     if not flow_run_id:
         raise ValueError("Invalid flow run ID.")
 
-    # Delete task run states and task runs _first_ to speedup deletion which can be
+    # Delete task run states and task runs first to speedup deletion which can be
     # _very_ slow on the large task tables due since they are implemented as
     # row-triggers and the foreign key checks are slow
 

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -10,7 +10,6 @@ from prefect.utilities.graphql import EnumValue
 from prefect.utilities.plugins import register_api
 from prefect_server import config
 from prefect_server.utilities import exceptions, names
-from prefect_server.database.hasura import HasuraClient
 
 
 SCHEDULED_STATES = [
@@ -425,7 +424,7 @@ async def delete_flow_run(flow_run_id: str) -> bool:
     # _very_ slow on the large task tables due since they are implemented as
     # row-triggers and the foreign key checks are slow
 
-    client = HasuraClient()
+    client = prefect.plugins.hasura.client
     result = await client.execute_mutations_in_transaction(
         # Use a transaction to maintain atomicity
         mutations=[


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

- Adds a transactional delete to `delete_flow_run` that first deletes `task_run_states` and `task_runs` outer -> innner rather than the default inner -> outer relationships
- Uses the `delete_flow_run` API to delete auto-scheduled flow runs

## Importance
<!-- Why is this PR important? -->

Closes #200 

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
