### PR TITLE
Add `APIError` to replace "database query error"

### DIFF
--- a/changes/pr204.yaml
+++ b/changes/pr204.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add `APIError` to replace 'database query error' and consolidate Cloud/Server exception types - [#204](https://github.com/PrefectHQ/server/pull/204)"

--- a/src/prefect_server/utilities/exceptions.py
+++ b/src/prefect_server/utilities/exceptions.py
@@ -86,7 +86,7 @@ async def reraise_as_api_error(
     try:
         yield
     except exception_type as exc:
-        if match and not re.search(match, str(exc)):
+        if match and not re.search(match, str(exc), re.IGNORECASE):
             raise
         if logger:
             logger.error(f"Encountered internal API exception: {exc}", exc_info=True)

--- a/src/prefect_server/utilities/exceptions.py
+++ b/src/prefect_server/utilities/exceptions.py
@@ -1,7 +1,9 @@
+import re
 from contextlib import asynccontextmanager
 from typing import Optional, Type, TYPE_CHECKING
 
 from graphql import GraphQLError
+
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -66,6 +68,7 @@ class Unauthorized(ApolloError):
 @asynccontextmanager
 async def reraise_as_api_error(
     exception_type: Type[Exception],
+    match: str = None,
     logger: "Logger" = None,
 ):
     """
@@ -74,6 +77,7 @@ async def reraise_as_api_error(
 
     Args:
         exception_type: The exception type to capture
+        match: An optional regex string to filter exceptions by
         logger: The logger to use to record the true exception
 
     Yields:
@@ -82,6 +86,8 @@ async def reraise_as_api_error(
     try:
         yield
     except exception_type as exc:
+        if match and not re.match(match, str(exc)):
+            raise
         if logger:
             logger.error(f"Encountered internal API exception: {exc}", exc_info=True)
         raise APIError() from exc

--- a/src/prefect_server/utilities/exceptions.py
+++ b/src/prefect_server/utilities/exceptions.py
@@ -86,7 +86,7 @@ async def reraise_as_api_error(
     try:
         yield
     except exception_type as exc:
-        if match and not re.match(match, str(exc)):
+        if match and not re.search(match, str(exc)):
             raise
         if logger:
             logger.error(f"Encountered internal API exception: {exc}", exc_info=True)

--- a/src/prefect_server/utilities/graphql.py
+++ b/src/prefect_server/utilities/graphql.py
@@ -55,7 +55,7 @@ class GraphQLClient:
             ariadne.gql(query)
 
         # Capture "connect" errors and re-raise as `APIError`
-        with reraise_as_api_error(Exception, match="connect", logger=self.logger):
+        async with reraise_as_api_error(Exception, match="connect", logger=self.logger):
             # timeout of 30 seconds
             response = await httpx_client.post(
                 self.url,

--- a/src/prefect_server/utilities/graphql.py
+++ b/src/prefect_server/utilities/graphql.py
@@ -8,6 +8,7 @@ from box import Box
 import prefect_server
 from prefect.utilities.graphql import parse_graphql
 from prefect_server.utilities.http import httpx_client
+from prefect_server.utilities.exceptions import reraise_as_api_error
 
 # define common objects for binding resolvers
 query = ariadne.QueryType()
@@ -53,7 +54,8 @@ class GraphQLClient:
         if prefect_server.config.debug:
             ariadne.gql(query)
 
-        try:
+        # Capture "connect" errors and re-raise as `APIError`
+        with reraise_as_api_error(Exception, match="connect", logger=self.logger):
             # timeout of 30 seconds
             response = await httpx_client.post(
                 self.url,
@@ -61,10 +63,7 @@ class GraphQLClient:
                 headers=headers or self.headers,
                 timeout=30,
             )
-        except Exception as exc:
-            if "connect" in str(exc).lower():
-                raise ValueError("database query error")
-            raise
+
         try:
             result = response.json()
         except json.decoder.JSONDecodeError as exc:

--- a/tests/utilities/test_exceptions.py
+++ b/tests/utilities/test_exceptions.py
@@ -15,9 +15,9 @@ class TestReraiseAsAPIError:
                 raise ValueError("TEST")
         assert "TEST" not in str(exc_info)
 
-    @pytest.mark.parametrize("match", ["TEST", "TEST (FOO|BAR)", "FOO"])
+    @pytest.mark.parametrize("match", ["TEST", "TEST (FOO|BAR)", "foo"])
     async def test_captures_specified_exception_with_match(self, match):
-        # Parameterized to test with substring match and regex
+        # Parameterized to test with substring matches, regex syntax, and ignore case
         with pytest.raises(APIError) as exc_info:
             async with reraise_as_api_error(ValueError, match=match):
                 raise ValueError("TEST FOO")

--- a/tests/utilities/test_exceptions.py
+++ b/tests/utilities/test_exceptions.py
@@ -15,7 +15,7 @@ class TestReraiseAsAPIError:
                 raise ValueError("TEST")
         assert "TEST" not in str(exc_info)
 
-    @pytest.mark.parametrize("match", ["TEST", "TEST (FOO|BAR)"])
+    @pytest.mark.parametrize("match", ["TEST", "TEST (FOO|BAR)", "FOO"])
     async def test_captures_specified_exception_with_match(self, match):
         # Parameterized to test with substring match and regex
         with pytest.raises(APIError) as exc_info:

--- a/tests/utilities/test_exceptions.py
+++ b/tests/utilities/test_exceptions.py
@@ -1,0 +1,41 @@
+import pytest
+from prefect_server.utilities.exceptions import reraise_as_api_error, APIError
+from prefect_server.utilities.logging import get_logger
+
+
+class TestReraiseAsAPIError:
+    async def test_does_not_capture_other_exceptions(self):
+        with pytest.raises(ValueError, match="TEST"):
+            async with reraise_as_api_error(TypeError):
+                raise ValueError("TEST")
+
+    async def test_captures_specified_exception(self):
+        with pytest.raises(APIError, match=APIError.__message__) as exc_info:
+            async with reraise_as_api_error(ValueError):
+                raise ValueError("TEST")
+        assert "TEST" not in str(exc_info)
+
+    async def test_logs_exception_information(self, caplog):
+        with pytest.raises(APIError):
+            async with reraise_as_api_error(Exception, logger=get_logger()):
+                raise ValueError("Test error")
+        assert caplog.records
+        log = caplog.records[0]
+        # Exc info attached
+        assert "ValueError: Test error" in log.exc_text
+        # Message includes original error message
+        assert log.message == "Encountered internal API exception: Test error"
+        # Logs as error
+        assert log.levelname == "ERROR"
+
+
+def test_api_error_is_always_same_message():
+    assert str(APIError()) == APIError.__message__
+
+
+def test_api_error_does_not_allow_custom_message():
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        APIError(message="Extra")
+
+    with pytest.raises(TypeError):
+        APIError("Foo")

--- a/tests/utilities/test_graphql.py
+++ b/tests/utilities/test_graphql.py
@@ -1,0 +1,12 @@
+import pytest
+from unittest.mock import MagicMock
+
+from prefect_server.utilities.graphql import GraphQLClient
+from prefect_server.utilities.exceptions import APIError
+
+
+async def test_graphql_client_connection_errors_reraised(monkeypatch):
+    mock = MagicMock(side_effect=ValueError("Failed to connect to foo"))
+    monkeypatch.setattr("prefect_server.utilities.graphql.httpx_client.post", mock)
+    with pytest.raises(APIError):
+        await GraphQLClient("localhost").execute(query="query { tenant { id } }")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

To improve error handling in Server and Cloud, we replace the obscure `ValueError("database query error")` with a simple `APIError` with a fixed message. This also consolidates the `ServerException` base into a `PrefectBackendException` in preparation for shared custom exceptions across Server/Cloud.

Supersedes https://github.com/PrefectHQ/cloud/pull/3103 and will require a follow-up in Cloud (https://github.com/PrefectHQ/cloud/pull/3144) to use these exceptions instead of doubly defined `CloudException` types.

## Importance
<!-- Why is this PR important? -->

Improves exception handling traces at a low level.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
