### PR TITLE
Use `delete_flow_run` API to delete scheduled runs on archive

### DIFF
--- a/changes/pr206.yaml
+++ b/changes/pr206.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Improve `archive_flow` performance with auto-scheduled flow runs - [#206](https://github.com/PrefectHQ/server/pull/206)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -355,14 +355,17 @@ async def archive_flow(flow_id: str) -> bool:
     if not result.affected_rows:
         return False
 
-    # delete scheduled flow runs
-    await models.FlowRun.where(
+    # Delete all auto-scheduled runs
+    runs_to_delete = await models.FlowRun.where(
         {
             "flow_id": {"_eq": flow_id},
             "state": {"_eq": "Scheduled"},
             "auto_scheduled": {"_eq": True},
         }
-    ).delete()
+    ).get({"id"})
+    await asyncio.gather(
+        *[api.runs.delete_flow_run(flow_run.id) for flow_run in runs_to_delete]
+    )
 
     # cancel adhoc scheduled flow runs
     fr_ids = await models.FlowRun.where(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Improves performance of auto-scheduled flow run deletion during `api.flows.archive_flow` by using the `delete_flow_run` API (#202)

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
