### PR TITLE
Allow agents to be created with empty settings

### DIFF
--- a/changes/pr207.yaml
+++ b/changes/pr207.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Allow `create_agent` to be called without passing settings - [#207](https://github.com/PrefectHQ/server/pull/207)"

--- a/src/prefect_server/api/agents.py
+++ b/src/prefect_server/api/agents.py
@@ -104,8 +104,8 @@ async def delete_agent(agent_id: str) -> bool:
 @register_api("agents.create_agent_config")
 async def create_agent_config(
     tenant_id: str,
-    name: str,
-    settings: dict,
+    name: str = None,
+    settings: dict = None,
 ) -> str:
     """
     Creates an agent config, returning its id
@@ -118,6 +118,8 @@ async def create_agent_config(
     Returns:
         - str: the agent config id
     """
+    settings = settings or {}
+
     return await models.AgentConfig(
         tenant_id=tenant_id, name=name, settings=settings
     ).insert()


### PR DESCRIPTION
Matching GQL API, field is not nullable in the DB


- [ ] Figure out how to use the PR template from the `gh` CLI
- [ ] Add relevant tests
- [x] Add changes entry 