### PR TITLE
Fix Helm UI and Core version tags

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -18,16 +18,14 @@ jobs:
         id: get_version
         run: |
           echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-          CORE_VERSION=$(\
+          echo ::set-output name=CORE_VERSION::$(\
             git ls-remote --tags --refs --sort="v:refname" \
             git://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
           )
-          echo ::set-output name=CORE_VERSION::core-$CORE_VERSION
-          UI_VERSION=$(\
+          echo ::set-output name=UI_VERSION::$(\
             git ls-remote --tags --refs --sort="v:refname" \
             git://github.com/PrefectHQ/ui.git | tail -n1 | sed 's/.*\///' \
           )
-          echo ::set-output name=UI_VERSION::$UI_VERSION
 
       - name: Configure Git
         run: |

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -57,7 +57,7 @@ jobs:
           mkdir /tmp/chart
           cd helm
           # Update the core version tag
-          gsed -i "s/^prefectVersionTag:.*$/prefectVersionTag: \"$CORE_VERSION\"/" prefect-server/values.yaml
+          sed -i "s/^prefectVersionTag:.*$/prefectVersionTag: \"$CORE_VERSION\"/" prefect-server/values.yaml
           helm package prefect-server \
             --destination /tmp/chart \
             --dependency-update \

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -23,6 +23,11 @@ jobs:
             git://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
           )
           echo ::set-output name=CORE_VERSION::core-$CORE_VERSION
+          UI_VERSION=$(\
+            git ls-remote --tags --refs --sort="v:refname" \
+            git://github.com/PrefectHQ/ui.git | tail -n1 | sed 's/.*\///' \
+          )
+          echo ::set-output name=UI_VERSION::$UI_VERSION
 
       - name: Configure Git
         run: |
@@ -58,6 +63,8 @@ jobs:
           cd helm
           # Update the core version tag
           sed -i "s/^prefectVersionTag:.*$/prefectVersionTag: \"$CORE_VERSION\"/" prefect-server/values.yaml
+          # Update the UI version tag
+          sed -i "s/^prefectVersionTag:.*$/uiVersionTag: \"$UI_VERSION\"/" prefect-server/values.yaml
           helm package prefect-server \
             --destination /tmp/chart \
             --dependency-update \
@@ -69,6 +76,7 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           CORE_VERSION: ${{ steps.get_version.outputs.CORE_VERSION }}
+          UI_VERSION: ${{ steps.get_version.outputs.UI_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -14,9 +14,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get the version tag
+      - name: Get the version tags
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: |
+          echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+          CORE_VERSION=$(\
+            git ls-remote --tags --refs --sort="v:refname" \
+            git://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
+          )
+          echo ::set-output name=CORE_VERSION::core-$CORE_VERSION
 
       - name: Configure Git
         run: |
@@ -48,8 +54,10 @@ jobs:
           
       - name: Package helm chart
         run: |
-          mkdir /tmp/chart &&
-          cd helm &&
+          mkdir /tmp/chart
+          cd helm
+          # Update the core version tag
+          gsed -i "s/^prefectVersionTag:.*$/prefectVersionTag: \"$CORE_VERSION\"/" prefect-server/values.yaml
           helm package prefect-server \
             --destination /tmp/chart \
             --dependency-update \
@@ -60,6 +68,7 @@ jobs:
             --passphrase-file $SIGN_PASSPHRASE_FILE
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
+          CORE_VERSION: ${{ steps.get_version.outputs.CORE_VERSION }}
           SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
           SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -74,15 +74,16 @@ jobs:
 
       - name: Update chart index
         run: |
-          git checkout gh-pages &&
+          git stash  # Stash changes to the values.yaml so checkout doesn't complain
+          git checkout gh-pages
           helm repo index /tmp/chart --url https://prefecthq.github.io/server/charts --merge ./index.yaml
 
       - name: Commit and push 
         run: |
-          cp /tmp/chart/index.yaml . &&
-          cp /tmp/chart/prefect-server-$VERSION.* ./charts &&
-          git add ./index.yaml ./charts/prefect-server-$VERSION.* &&
-          git commit -m "Release $VERSION" &&
+          cp /tmp/chart/index.yaml .
+          cp /tmp/chart/prefect-server-$VERSION.* ./charts
+          git add ./index.yaml ./charts/prefect-server-$VERSION.*
+          git commit -m "Release $VERSION"
           git push origin gh-pages
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -64,7 +64,7 @@ jobs:
           # Update the core version tag
           sed -i "s/^prefectVersionTag:.*$/prefectVersionTag: \"$CORE_VERSION\"/" prefect-server/values.yaml
           # Update the UI version tag
-          sed -i "s/^prefectVersionTag:.*$/uiVersionTag: \"$UI_VERSION\"/" prefect-server/values.yaml
+          sed -i "s/^uiVersionTag:.*$/uiVersionTag: \"$UI_VERSION\"/" prefect-server/values.yaml
           helm package prefect-server \
             --destination /tmp/chart \
             --dependency-update \

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -203,9 +203,14 @@ The `appVersion` will always match the `version` of an official release.
 
 If you need to override the version of the Server image tags, you may do so globally with `--set serverVersionTag=<VERSION>` or override each service individually.
 
-There are some optional services that use Prefect Core images (the agent and tenant creation job).
-These images follow the value of `prefectVersionTag` which defaults to `latest`.
-If using the agent in production, we recommend pinning this version to the version of Prefect you are using to ensure the agent matches your flow.
+Some services use the Prefect Core version tags, including:
+- UI
+- Agent (optional)
+- Create tenant job (optional)
+
+These images follow the value of `prefectVersionTag` which is pinned to the latest core release on chart release.
+You may want to manage this version tag separately as Prefect Core is released more frequently than the Server.
+If using the agent in production, we recommend ensuring this version matches the version of Prefect you are using to ensure the agent matches your flow.
 
 
 ### Development

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -215,14 +215,11 @@ The `appVersion` will always match the `version` of an official release.
 
 If you need to override the version of the Server image tags, you may do so globally with `--set serverVersionTag=<VERSION>` or override each service individually.
 
-Some services use the Prefect Core version tags, including:
-- UI
-- Agent (optional)
-- Create tenant job (optional)
+Some services rely on related Prefect images. 
+These are set using `prefectVersionTag` and `uiVersionTag` which is pinned to the latest releases on chart release.
+You may want to manage these version tags separately as Prefect Core and the UI are released more frequently than the Server.
 
-These images follow the value of `prefectVersionTag` which is pinned to the latest core release on chart release.
-You may want to manage this version tag separately as Prefect Core is released more frequently than the Server.
-If using the agent in production, we recommend ensuring this version matches the version of Prefect you are using to ensure the agent matches your flow.
+If using the agent in production, we recommend ensuring `prefectVersionTag` matches the version of Prefect you are using to ensure the agent matches your flow.
 
 
 ### Development

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -149,6 +149,18 @@ Development versions of the Helm chart will always be available directly from th
     $ helm upgrade $NAME .
     ```
 
+3. Upgrades can also be used enable features or change options
+
+    ```shell
+    NAME=prefect-server
+
+    helm upgrade \
+        $NAME \
+        prefecthq/prefect-server \
+        --set agent.enabled=true \
+        --set jobs.createTenant.enabled=true
+    ```
+
 
 #### Important notes about upgrading
 

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -36,8 +36,7 @@ spec:
         securityContext:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- /* We need to trim `core-` off the prefectVersionTag to include the K8s orchestration extras */}}
-        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default (.Values.prefectVersionTag | replace "core-" "") }}"
+        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Values.prefectVersionTag }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy  }}
         command:
           - bash

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         securityContext:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- /* We need to trim `core-` off the prefectVersionTag to include the K8s orchestration extras */ }}
+        {{- /* We need to trim `core-` off the prefectVersionTag to include the K8s orchestration extras */}}
         image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default (.Values.prefectVersionTag | replace "core-" "") }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy  }}
         command:

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -36,7 +36,8 @@ spec:
         securityContext:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default .Values.prefectVersionTag }}"
+        {{- /* We need to trim `core-` off the prefectVersionTag to include the K8s orchestration extras */ }}
+        image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag |  default (.Values.prefectVersionTag | replace "core-" "") }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy  }}
         command:
           - bash

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.ui.image.name }}:{{ .Values.ui.image.tag |  default .Values.serverVersionTag | default .Chart.AppVersion }}"
+          image: "{{ .Values.ui.image.name }}:{{ .Values.ui.image.tag | default .Values.prefectVersionTag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy  }}
           command: 
             - "/intercept.sh"

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.ui.image.name }}:{{ .Values.ui.image.tag | default .Values.prefectVersionTag }}"
+          image: "{{ .Values.ui.image.name }}:{{ .Values.ui.image.tag | default .Values.uiVersionTag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy  }}
           command: 
             - "/intercept.sh"

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -10,9 +10,13 @@
 # on why the `appVersion` cannot be set at install time.
 serverVersionTag: null
 
-# prefectVersionTag configures the default tag for prefect core
-# images which are used for the create-tenant job and agent both
-# of which are optional and disabled by default
+# prefectVersionTag configures the default tag for related Prefect
+# services which include:
+# - UI
+# - Agent (optional)
+# - Default tenant creation job (optional)
+# This value is automatically pinned on chart release to the current
+# core version.
 prefectVersionTag: "latest"
 
 # imagePullSecrets provides configuration to reference the k8s Secret

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -10,14 +10,17 @@
 # on why the `appVersion` cannot be set at install time.
 serverVersionTag: null
 
-# prefectVersionTag configures the default tag for related Prefect
-# services which include:
-# - UI
-# - Agent (optional)
-# - Default tenant creation job (optional)
-# This value is automatically pinned on chart release to the current
+# prefectVersionTag configures the default tag for Prefect Core based
+# services, including the agent and default tenant creation job.
+# This value is automatically pinned on chart release to the latest
 # core version.
 prefectVersionTag: "latest"
+
+# uiVersionTag configures the default tag for the Prefect UI service.
+# It is defined here for easy update using `sed` for automation.
+# This value is automatically pinned on chart release to the latest
+# ui version.
+uiVersionTag: "latest"
 
 # imagePullSecrets provides configuration to reference the k8s Secret
 # resources the Helm chart's pods can get credentials from to pull
@@ -215,7 +218,7 @@ ui:
 
   image:
     name: prefecthq/ui
-    tag: null
+    tag: null  # See `uiVersionTag` instead
     pullPolicy: Always
     pullSecrets: []
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Of course, in #209 I was testing a tag that _also_ existed in the UI but the UI is not guaranteed to be released at the same time as Server. Therefore the UI needs to rely on a different tag.

Now, we'll pull the latest core and UI tags and set them in `values.yaml` for the agent/ui.

## Importance
<!-- Why is this PR important? -->

The existing helm chart is broken :( will need to be re-released.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~
