### PR TITLE
Streamline background scheduling

### DIFF
--- a/src/prefect_server/cli/dev.py
+++ b/src/prefect_server/cli/dev.py
@@ -8,12 +8,12 @@ import time
 from pathlib import Path
 
 import click
+import prefect
 import sqlalchemy
 from click.testing import CliRunner
-
-import prefect
-import prefect_server
 from prefect import models
+
+import prefect_server
 from prefect_server import config
 
 
@@ -239,7 +239,7 @@ def clear_data():
     """
 
     async def _clear_data():
-        await models.Project.where().delete()
+        await models.Tenant.where().delete()
 
     asyncio.run(_clear_data())
     click.secho("Done!", fg="green")

--- a/tests/api/test_cloud_hooks.py
+++ b/tests/api/test_cloud_hooks.py
@@ -3,15 +3,15 @@ import uuid
 from unittest.mock import MagicMock
 
 import pendulum
+import prefect
 import pytest
 import uvicorn
 from asynctest import CoroutineMock
+from prefect import api, models
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-import prefect
-from prefect import api, models
 from prefect_server import config
 from prefect_server.utilities import events, exceptions, tests
 
@@ -464,7 +464,7 @@ class TestMatchHooks:
         # sleep to allow hooks to fire
         await asyncio.sleep(0.1)
 
-        assert {h.id for h in matched_hooks} == {hook_id_1}
+        assert hook_id_1 in {h.id for h in matched_hooks}
 
     async def test_matching_does_not_respect_state_parents(
         self, tenant_id, flow_run_id, matched_hooks

--- a/tests/api/test_flow_groups.py
+++ b/tests/api/test_flow_groups.py
@@ -261,12 +261,12 @@ class TestSetFlowGroupSchedule:
 
         # make sure we're starting from a clean slate
         # sleep to allow background scheduled runs to complete
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
         await api.flows.set_schedule_active(flow_id=flow_id)
         # runs are created in the background, so we need to sleep here
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
         # create one manual run that won't be deleted
         await api.runs.create_flow_run(flow_id=flow_id)
@@ -383,14 +383,14 @@ class TestDeleteFlowGroupSchedule:
         clock = {"type": "CronClock", "cron": "42 0 0 * * *"}
 
         # finish background scheduling
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         success = await api.flow_groups.set_flow_group_schedule(
             flow_group_id=flow_group_id, clocks=[clock]
         )
         assert success is True
 
         await api.flows.set_schedule_active(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
         success = await api.flow_groups.delete_flow_group_schedule(

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -833,13 +833,13 @@ class TestUnarchiveFlow:
 
     async def test_unarchive_schedules_new_runs(self, flow_id):
         # sleep for background scheduling
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await api.flows.archive_flow(flow_id=flow_id)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.unarchive_flow(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
 
@@ -1036,24 +1036,24 @@ class TestSetScheduleActive:
 
     async def test_set_schedule_active_schedules_new_runs(self, flow_id):
         # sleep for background scheduling
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
     async def test_set_schedule_active_doesnt_duplicate_runs(self, flow_id):
         # sleep for background scheduling
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await api.flows.set_schedule_active(flow_id=flow_id)
 
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
@@ -1089,13 +1089,13 @@ class TestSetScheduleInactive:
     async def test_set_schedule_inactive_deletes_only_auto_scheduled_runs(
         self, flow_id
     ):
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
         # create one manual run that won't be deleted
         await api.runs.create_flow_run(flow_id=flow_id)
@@ -1119,12 +1119,12 @@ class TestSetScheduleInactive:
         api.runs.
         """
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1132,11 +1132,11 @@ class TestSetScheduleInactive:
         start_times = {r.scheduled_start_time for r in runs}
 
         await api.flows.set_schedule_inactive(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         new_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1159,12 +1159,12 @@ class TestSetScheduleInactive:
             serialized_flow=flow.serialize(), project_id=project_id
         )
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1172,11 +1172,11 @@ class TestSetScheduleInactive:
         start_times = {r.scheduled_start_time for r in runs}
 
         await api.flows.set_schedule_inactive(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         new_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1447,13 +1447,13 @@ class TestScheduleRuns:
         await api.flows.create_flow(
             project_id=project_id, serialized_flow=flow.serialize()
         )
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where().count() == run_count + 10
 
     async def test_schedule_max_runs(self, flow_id):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         await api.flows.schedule_flow_runs(flow_id, max_runs=50)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 50
 
     async def test_schedule_flow_runs_with_no_id(self):
@@ -1471,12 +1471,12 @@ class TestScheduleRuns:
         )
 
         # ensure the flow's schedule is active
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         await models.Flow.where(id=flow_id).update(set=dict(is_schedule_active=True))
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
 
         await api.flows.schedule_flow_runs(flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
     async def test_schedule_runs_gives_preference_to_flow_group_schedule(
@@ -1502,7 +1502,7 @@ class TestScheduleRuns:
 
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         await api.flows.schedule_flow_runs(flow_id)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         # assert the 10 scheduled runs were scheduled months out, not for the next 10 minutes
         flow_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             selection_set={"scheduled_start_time"},

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1,11 +1,11 @@
+import asyncio
 import datetime
 import uuid
 
 import pendulum
+import prefect
 import pydantic
 import pytest
-
-import prefect
 from prefect import api, models
 from prefect.utilities.graphql import EnumValue
 
@@ -832,11 +832,14 @@ class TestUnarchiveFlow:
             await api.flows.unarchive_flow(flow_id=None)
 
     async def test_unarchive_schedules_new_runs(self, flow_id):
+        # sleep for background scheduling
+        await asyncio.sleep(0.5)
         await api.flows.archive_flow(flow_id=flow_id)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.unarchive_flow(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
 
@@ -1032,18 +1035,25 @@ class TestSetScheduleActive:
         assert flow.is_schedule_active is True
 
     async def test_set_schedule_active_schedules_new_runs(self, flow_id):
+        # sleep for background scheduling
+        await asyncio.sleep(0.5)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
 
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
     async def test_set_schedule_active_doesnt_duplicate_runs(self, flow_id):
+        # sleep for background scheduling
+        await asyncio.sleep(0.5)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
+
+        await asyncio.sleep(0.5)
         await api.flows.set_schedule_active(flow_id=flow_id)
 
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
@@ -1079,11 +1089,13 @@ class TestSetScheduleInactive:
     async def test_set_schedule_inactive_deletes_only_auto_scheduled_runs(
         self, flow_id
     ):
+        await asyncio.sleep(0.5)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
 
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
         # create one manual run that won't be deleted
         await api.runs.create_flow_run(flow_id=flow_id)
@@ -1107,10 +1119,12 @@ class TestSetScheduleInactive:
         api.runs.
         """
 
+        await asyncio.sleep(0.5)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1118,9 +1132,11 @@ class TestSetScheduleInactive:
         start_times = {r.scheduled_start_time for r in runs}
 
         await api.flows.set_schedule_inactive(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         new_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1143,10 +1159,12 @@ class TestSetScheduleInactive:
             serialized_flow=flow.serialize(), project_id=project_id
         )
 
+        await asyncio.sleep(0.5)
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1154,9 +1172,11 @@ class TestSetScheduleInactive:
         start_times = {r.scheduled_start_time for r in runs}
 
         await api.flows.set_schedule_inactive(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 
         await api.flows.set_schedule_active(flow_id=flow_id)
+        await asyncio.sleep(0.5)
         new_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             {"scheduled_start_time"}
         )
@@ -1427,11 +1447,13 @@ class TestScheduleRuns:
         await api.flows.create_flow(
             project_id=project_id, serialized_flow=flow.serialize()
         )
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where().count() == run_count + 10
 
     async def test_schedule_max_runs(self, flow_id):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         await api.flows.schedule_flow_runs(flow_id, max_runs=50)
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 50
 
     async def test_schedule_flow_runs_with_no_id(self):
@@ -1449,10 +1471,12 @@ class TestScheduleRuns:
         )
 
         # ensure the flow's schedule is active
+        await asyncio.sleep(0.5)
         await models.Flow.where(id=flow_id).update(set=dict(is_schedule_active=True))
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
 
         await api.flows.schedule_flow_runs(flow_id)
+        await asyncio.sleep(0.5)
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 10
 
     async def test_schedule_runs_gives_preference_to_flow_group_schedule(
@@ -1478,6 +1502,7 @@ class TestScheduleRuns:
 
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         await api.flows.schedule_flow_runs(flow_id)
+        await asyncio.sleep(0.5)
         # assert the 10 scheduled runs were scheduled months out, not for the next 10 minutes
         flow_runs = await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).get(
             selection_set={"scheduled_start_time"},

--- a/tests/graphql/test_cloud_hooks.py
+++ b/tests/graphql/test_cloud_hooks.py
@@ -4,12 +4,12 @@ from unittest.mock import MagicMock
 import pytest
 import uvicorn
 from asynctest import CoroutineMock
+from prefect import api, models
+from prefect.engine.state import Failed, Running, Success
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from prefect import api, models
-from prefect.engine.state import Failed, Running, Success
 from prefect_server import config
 from prefect_server.utilities import tests
 
@@ -367,7 +367,7 @@ class TestTestWebhook:
         assert event["id"] == call_args[1]["headers"]["X-PREFECT-EVENT-ID"]
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_webhook_with_custom_state(
         self, run_query, tenant_id, state_type, cloud_hook_mock
@@ -395,7 +395,7 @@ class TestTestWebhook:
         )
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_slack_cloud_hook(
         self, run_query, tenant_id, state_type, cloud_hook_mock
@@ -405,7 +405,7 @@ class TestTestWebhook:
             tenant_id=tenant_id,
             type="SLACK_WEBHOOK",
             config={"url": "http://0.0.0.0:8100/hook"},
-            states=["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"],
+            states=["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"],
         )
 
         await run_query(
@@ -453,7 +453,7 @@ class TestTestWebhook:
         assert blocks[2]["text"]["text"] == f"*Message:* Test {'SUCCESS'.lower()} state"
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_prefect_message_webhook(
         self, run_query, tenant_id, flow_run_id, state_type
@@ -477,7 +477,7 @@ class TestTestWebhook:
         assert len(messages) == 1
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_prefect_message_webhook_while_specifying_flow_run_id(
         self, run_query, tenant_id, flow_run_id, state_type
@@ -507,7 +507,7 @@ class TestTestWebhook:
         assert len(messages) == 1
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_twilio_cloud_hook(
         self, run_query, tenant_id, flow_id, flow_run_id, monkeypatch, state_type
@@ -558,7 +558,7 @@ class TestTestWebhook:
         )
 
     @pytest.mark.parametrize(
-        "state_type", ["SUBMITTED", "SCHEDULED", "RUNNING", "SUCCESS", "FAILED"]
+        "state_type", ["SUBMITTED", "RUNNING", "SUCCESS", "FAILED"]
     )
     async def test_test_pagerduty_cloud_hook(
         self, run_query, tenant_id, flow_id, flow_run_id, monkeypatch, state_type


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Depends on #218 and #219

This PR moves scheduling of flow runs to a background task with significant performance gains, especially for unit tests (where every fixture-created flow schedules at least 10 runs)


## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
