### PR TITLE
Update scheduler to have deterministic order

### DIFF
--- a/changes/pr215.yaml
+++ b/changes/pr215.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Ensure the scheduler queries with deterministic order - [#215](https://github.com/PrefectHQ/server/pull/215)"

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -2,6 +2,7 @@ import asyncio
 
 from prefect import api, models
 from prefect.utilities.graphql import EnumValue
+
 from prefect_server.services.loop_service import LoopService
 
 
@@ -41,7 +42,7 @@ class Scheduler(LoopService):
                     "id",
                 },
                 # deterministic sort for batching
-                order_by=["id"],
+                order_by=[{"id": EnumValue("desc")}],
                 limit=500,
                 offset=500 * iterations,
             )

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -15,7 +15,7 @@ class Scheduler(LoopService):
     """
 
     loop_seconds_config_key = "services.scheduler.scheduler_loop_seconds"
-    loop_seconds_default = 300
+    loop_seconds_default = 150
 
     async def run_once(self) -> int:
         """
@@ -40,13 +40,8 @@ class Scheduler(LoopService):
                 selection_set={
                     "id",
                 },
-                order_by=[
-                    {
-                        "flow_runs_aggregate": {
-                            "max": {"scheduled_start_time": EnumValue("asc_nulls_last")}
-                        }
-                    }
-                ],
+                # deterministic sort for batching
+                order_by=["id"],
                 limit=500,
                 offset=500 * iterations,
             )


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
The scheduler currently orders flows by maximum scheduled start time, such that a flow (A) with its last scheduled run starting in one hour is prioritized over a flow (B) with its last scheduled run starting in one day.

However, this order could lead to flows being skipped across multiple batches. Consider if `A` is scheduled in the first batch of 500 flows, and `B` is the 501st flow. The scheduler schedules `A` such that it's maximum scheduled start time becomes later. This makes `B` the 500th flow, not the 501st. Therefore, when the scheduler queries for the second batch, it doesn't pick up `B`.

This circumstance is highly unusual due to the practical manner in which scheduling works (flows don't typically get to a point where they have a very low maximum scheduled start time and then suddenly a very high maximum scheduled start time), but it is possible and this PR closes it with a deterministic sort by ID. In order to reduce any minor concern about prioritizing flows in need of scheduling, it also doubles the scheduler loop interval.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
