### PR TITLE
Set uvicorn server log level

### DIFF
--- a/changes/pr217.yml
+++ b/changes/pr217.yml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Set uvicorn server log level - [#217](https://github.com/PrefectHQ/server/pull/217)"
+
+contributor:
+  - "[Peter Roelants](https://github.com/peterroelants)"

--- a/changes/pr217.yml
+++ b/changes/pr217.yml
@@ -1,5 +1,5 @@
 enhancement:
-  - "Set uvicorn server log level - [#217](https://github.com/PrefectHQ/server/pull/217)"
+  - "Set uvicorn server log level and access logs - [#217](https://github.com/PrefectHQ/server/pull/217)"
 
 contributor:
   - "[Peter Roelants](https://github.com/peterroelants)"

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -70,6 +70,7 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
     port = 4201
     debug = false
     path = "/graphql/"
+    disable_access_logs = false
 
     [services.scheduler]
     # run scheduler every 5 minutes

--- a/src/prefect_server/services/graphql/server.py
+++ b/src/prefect_server/services/graphql/server.py
@@ -51,9 +51,24 @@ def health(request: Request) -> JSONResponse:
     return JSONResponse(dict(status="ok", version=app_version))
 
 
+def _get_uvicorn_log_level():
+    prefect_log_level = prefect_server.configuration.config["logging"]["level"]
+    # Uvicorn log levels are lower case
+    uvicorn_log_level = prefect_log_level.lower()
+    if uvicorn_log_level in uvicorn.config.LOG_LEVELS:
+        logger.info(f"Using uvicorn log level = {repr(uvicorn_log_level)}")
+        return uvicorn_log_level
+    else:
+        logger.warning(
+            f"{repr(uvicorn_log_level)} not a valid uvicorn log level, falling back on default."
+        )
+        return None
+
+
 if __name__ == "__main__":
     uvicorn.run(
         app,
         host=prefect_server.config.services.graphql.host,
         port=prefect_server.config.services.graphql.port,
+        log_level=_get_uvicorn_log_level(),
     )

--- a/src/prefect_server/services/graphql/server.py
+++ b/src/prefect_server/services/graphql/server.py
@@ -60,7 +60,7 @@ def _get_uvicorn_log_level():
         return uvicorn_log_level
     else:
         logger.warning(
-            f"{repr(uvicorn_log_level)} not a valid uvicorn log level, falling back on default."
+            f"{uvicorn_log_level!r} not a valid uvicorn log level, falling back on default."
         )
         return None
 

--- a/src/prefect_server/services/graphql/server.py
+++ b/src/prefect_server/services/graphql/server.py
@@ -56,7 +56,7 @@ def _get_uvicorn_log_level():
     # Uvicorn log levels are lower case
     uvicorn_log_level = prefect_log_level.lower()
     if uvicorn_log_level in uvicorn.config.LOG_LEVELS:
-        logger.info(f"Using uvicorn log level = {repr(uvicorn_log_level)}")
+        logger.info(f"Using uvicorn log level = {uvicorn_log_level!r}")
         return uvicorn_log_level
     else:
         logger.warning(

--- a/src/prefect_server/services/graphql/server.py
+++ b/src/prefect_server/services/graphql/server.py
@@ -52,7 +52,7 @@ def health(request: Request) -> JSONResponse:
 
 
 def _get_uvicorn_log_level():
-    prefect_log_level = prefect_server.configuration.config["logging"]["level"]
+    prefect_log_level = prefect_server.configuration.config.logging.level
     # Uvicorn log levels are lower case
     uvicorn_log_level = prefect_log_level.lower()
     if uvicorn_log_level in uvicorn.config.LOG_LEVELS:
@@ -71,4 +71,5 @@ if __name__ == "__main__":
         host=prefect_server.config.services.graphql.host,
         port=prefect_server.config.services.graphql.port,
         log_level=_get_uvicorn_log_level(),
+        access_log=not prefect_server.configuration.config.services.graphql.disable_access_logs,
     )


### PR DESCRIPTION
## Summary
Set graphql uvicorn server log level based on Prefect config.

Solves https://github.com/PrefectHQ/server/issues/216


## Importance
Allows the user to control the access logs of the Prefect GraphQL service (which can become quite large on the default `DEBUG` level).


## Checklist

This PR:

- [x] adds new tests (N/A)
- [x] adds a change file in the `changes/` directory (if appropriate)
