### PR TITLE
Fix situation where trigger doesn't fire if state version matches run

### DIFF
--- a/changes/pr218.yaml
+++ b/changes/pr218.yaml
@@ -1,0 +1,20 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Avoid situation where runs and states don't update because they have the same or missing versions - [#218](https://github.com/PrefectHQ/server/pull/218)"

--- a/changes/pr218.yaml
+++ b/changes/pr218.yaml
@@ -16,5 +16,5 @@
 #
 # Here's an example of a PR that adds an enhancement
 
-fix:
-  - "Avoid situation where runs and states don't update because they have the same or missing versions - [#218](https://github.com/PrefectHQ/server/pull/218)"
+migration:
+  - "Improve run detail triggers when version is the same or missing - [#218](https://github.com/PrefectHQ/server/pull/218)"

--- a/services/hasura/migrations/versions/metadata-459a61bedc9e.yaml
+++ b/services/hasura/migrations/versions/metadata-459a61bedc9e.yaml
@@ -1,0 +1,272 @@
+functions:
+- function:
+    name: downstream_tasks
+    schema: utility
+- function:
+    name: upstream_tasks
+    schema: utility
+tables:
+- array_relationships:
+  - name: agents
+    using:
+      foreign_key_constraint_on:
+        column: agent_config_id
+        table:
+          name: agent
+          schema: public
+  table:
+    name: agent_config
+    schema: public
+- array_relationships:
+  - name: downstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: upstream_task_id
+        table:
+          name: edge
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          name: task_run
+          schema: public
+  - name: upstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: downstream_task_id
+        table:
+          name: edge
+          schema: public
+  object_relationships:
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  table:
+    name: task
+    schema: public
+- array_relationships:
+  - name: edges
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: edge
+          schema: public
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_run
+          schema: public
+  - name: tasks
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: task
+          schema: public
+  object_relationships:
+  - name: flow_group
+    using:
+      foreign_key_constraint_on: flow_group_id
+  - name: project
+    using:
+      foreign_key_constraint_on: project_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow
+    schema: public
+- array_relationships:
+  - name: flow_groups
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow_group
+          schema: public
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow
+          schema: public
+  - name: projects
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: project
+          schema: public
+  table:
+    name: tenant
+    schema: public
+- array_relationships:
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: agent_id
+        table:
+          name: flow_run
+          schema: public
+  object_relationships:
+  - name: agent_config
+    using:
+      foreign_key_constraint_on: agent_config_id
+  table:
+    name: agent
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: flow_group_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_group
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: project
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: flow_run_state
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: task_run
+          schema: public
+  object_relationships:
+  - name: agent
+    using:
+      foreign_key_constraint_on: agent_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_run
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: task_run_state
+          schema: public
+  object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  - name: task
+    using:
+      foreign_key_constraint_on: task_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: task_run
+    schema: public
+- object_relationships:
+  - name: downstream_task
+    using:
+      foreign_key_constraint_on: downstream_task_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+  table:
+    name: edge
+    schema: public
+- object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  table:
+    name: flow_run_state
+    schema: public
+- object_relationships:
+  - name: task
+    using:
+      manual_configuration:
+        column_mapping:
+          task_id: id
+        remote_table:
+          name: task
+          schema: public
+  table:
+    name: traversal
+    schema: utility
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_artifact
+    schema: public
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_state
+    schema: public
+- table:
+    name: cloud_hook
+    schema: public
+- table:
+    name: log
+    schema: public
+- table:
+    name: message
+    schema: public
+version: 2

--- a/services/postgres/alembic/versions/2021-03-16T221106_improve_run_triggers_to_handle_same_.py
+++ b/services/postgres/alembic/versions/2021-03-16T221106_improve_run_triggers_to_handle_same_.py
@@ -1,0 +1,158 @@
+"""
+Improve run triggers to handle same-version states
+
+Revision ID: 459a61bedc9e
+Revises: 9116e81c6dc2
+Create Date: 2021-03-16 22:11:06.618713
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+# revision identifiers, used by Alembic.
+revision = "459a61bedc9e"
+down_revision = "9116e81c6dc2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        DROP FUNCTION update_flow_run_details_on_state_insert CASCADE;
+        DROP FUNCTION update_task_run_details_on_state_insert CASCADE;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_flow_run_details_on_state_insert()
+            RETURNS TRIGGER AS $$
+            	BEGIN
+            	    UPDATE flow_run
+            	    SET 
+            	    	start_time = CASE WHEN NEW.version >= COALESCE(version, 0) AND NEW.state = 'Running' THEN LEAST(start_time, NEW.timestamp) ELSE start_time END,
+            	    	end_time = CASE WHEN NEW.version >= COALESCE(version, 0) AND NEW.state in ('Success', 'Failed', 'Cached', 'TimedOut', 'Looped', 'Cancelled') THEN GREATEST(end_time, NEW.timestamp) ELSE end_time END,
+            	    	version = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.version ELSE version END,
+        	            state = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.state ELSE state END,
+             	        serialized_state = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.serialized_state ELSE serialized_state END,
+  	            	    state_start_time = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.start_time ELSE state_start_time END,
+    	                state_timestamp = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.timestamp ELSE state_timestamp END,
+        	            state_message = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.message ELSE state_message END,
+            	        state_result = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.result ELSE state_result END
+            	    WHERE id = NEW.flow_run_id;
+            	    RETURN NEW;
+            	END;
+            
+            $$
+            LANGUAGE plpgsql;
+
+        CREATE OR REPLACE FUNCTION update_task_run_details_on_state_insert()
+            RETURNS TRIGGER AS $$
+            	BEGIN
+            	    UPDATE task_run
+            	    SET 
+            	    	start_time = CASE WHEN NEW.version >= COALESCE(version, 0) AND NEW.state = 'Running' THEN LEAST(start_time, NEW.timestamp) ELSE start_time END,
+            	    	end_time = CASE WHEN NEW.version >= COALESCE(version, 0) AND NEW.state in ('Success', 'Failed', 'Cached', 'TimedOut', 'Looped', 'Cancelled') THEN GREATEST(end_time, NEW.timestamp) ELSE end_time END,
+            	    	version = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.version ELSE version END,
+        	            state = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.state ELSE state END,
+             	        serialized_state = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.serialized_state ELSE serialized_state END,
+  	            	    state_start_time = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.start_time ELSE state_start_time END,
+    	                state_timestamp = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.timestamp ELSE state_timestamp END,
+        	            state_message = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.message ELSE state_message END,
+            	        state_result = CASE WHEN NEW.version >= COALESCE(version, 0) THEN NEW.result ELSE state_result END
+            	    WHERE id = NEW.task_run_id;
+            	    RETURN NEW;
+            	END;
+            
+            $$
+            LANGUAGE plpgsql;
+        """
+    )
+
+    # create triggers
+    op.execute(
+        """
+        CREATE TRIGGER update_flow_run_details_on_state_insert
+        AFTER INSERT ON flow_run_state
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_flow_run_details_on_state_insert();
+
+
+        CREATE TRIGGER update_task_run_details_on_state_insert
+        AFTER INSERT ON task_run_state
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_task_run_details_on_state_insert();
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DROP FUNCTION update_flow_run_details_on_state_insert CASCADE;
+        DROP FUNCTION update_task_run_details_on_state_insert CASCADE;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_flow_run_details_on_state_insert()
+            RETURNS TRIGGER AS $$
+            	BEGIN
+            	    UPDATE flow_run
+            	    SET 
+            	    	start_time = CASE WHEN NEW.version > version AND NEW.state = 'Running' THEN LEAST(start_time, NEW.timestamp) ELSE start_time END,
+            	    	end_time = CASE WHEN NEW.version > version AND NEW.state in ('Success', 'Failed', 'Cached', 'TimedOut', 'Looped', 'Cancelled') THEN GREATEST(end_time, NEW.timestamp) ELSE end_time END,
+            	    	version = CASE WHEN NEW.version > version THEN NEW.version ELSE version END,
+        	            state = CASE WHEN NEW.version > version THEN NEW.state ELSE state END,
+             	        serialized_state = CASE WHEN NEW.version > version THEN NEW.serialized_state ELSE serialized_state END,
+  	            	    state_start_time = CASE WHEN NEW.version > version THEN NEW.start_time ELSE state_start_time END,
+    	                state_timestamp = CASE WHEN NEW.version > version THEN NEW.timestamp ELSE state_timestamp END,
+        	            state_message = CASE WHEN NEW.version > version THEN NEW.message ELSE state_message END,
+            	        state_result = CASE WHEN NEW.version > version THEN NEW.result ELSE state_result END
+            	    WHERE id = NEW.flow_run_id;
+            	    RETURN NEW;
+            	END;
+            
+            $$
+            LANGUAGE plpgsql;
+
+        CREATE OR REPLACE FUNCTION update_task_run_details_on_state_insert()
+            RETURNS TRIGGER AS $$
+            	BEGIN
+            	    UPDATE task_run
+            	    SET 
+            	    	start_time = CASE WHEN NEW.version > version AND NEW.state = 'Running' THEN LEAST(start_time, NEW.timestamp) ELSE start_time END,
+            	    	end_time = CASE WHEN NEW.version > version AND NEW.state in ('Success', 'Failed', 'Cached', 'TimedOut', 'Looped', 'Cancelled') THEN GREATEST(end_time, NEW.timestamp) ELSE end_time END,
+            	    	version = CASE WHEN NEW.version > version THEN NEW.version ELSE version END,
+        	            state = CASE WHEN NEW.version > version THEN NEW.state ELSE state END,
+             	        serialized_state = CASE WHEN NEW.version > version THEN NEW.serialized_state ELSE serialized_state END,
+  	            	    state_start_time = CASE WHEN NEW.version > version THEN NEW.start_time ELSE state_start_time END,
+    	                state_timestamp = CASE WHEN NEW.version > version THEN NEW.timestamp ELSE state_timestamp END,
+        	            state_message = CASE WHEN NEW.version > version THEN NEW.message ELSE state_message END,
+            	        state_result = CASE WHEN NEW.version > version THEN NEW.result ELSE state_result END
+            	    WHERE id = NEW.task_run_id;
+            	    RETURN NEW;
+            	END;
+            
+            $$
+            LANGUAGE plpgsql;
+        """
+    )
+
+    # create triggers
+    op.execute(
+        """
+        CREATE TRIGGER update_flow_run_details_on_state_insert
+        AFTER INSERT ON flow_run_state
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_flow_run_details_on_state_insert();
+
+
+        CREATE TRIGGER update_task_run_details_on_state_insert
+        AFTER INSERT ON task_run_state
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_task_run_details_on_state_insert();
+        """
+    )

--- a/tests/database/test_state_triggers.py
+++ b/tests/database/test_state_triggers.py
@@ -4,7 +4,6 @@ associated run's details via Postgres trigger
 """
 import pendulum
 import pytest
-
 from prefect import models
 
 
@@ -14,7 +13,9 @@ class TestFlowRunStateTrigger:
         self, tenant_id, flow_run_id, original_version
     ):
 
-        await models.FlowRun.where(id=flow_run_id).update({"version": original_version})
+        await models.FlowRun.where(id=flow_run_id).update(
+            {"version": original_version, "message": "original"}
+        )
         old_run = await models.FlowRun.where(id=flow_run_id).first({"version"})
 
         dt = pendulum.now("UTC")
@@ -31,9 +32,13 @@ class TestFlowRunStateTrigger:
             serialized_state={"a": "b"},
         ).insert()
 
-        new_run = await models.FlowRun.where(id=flow_run_id).first({"version"})
+        new_run = await models.FlowRun.where(id=flow_run_id).first(
+            {"version", "state", "state_message"}
+        )
 
         assert new_run.version == 10
+        assert new_run.state_message == "x"
+        assert new_run.state == "z"
 
     async def test_trigger_updates_highest_version_when_multiple_states_inserted(
         self, tenant_id, flow_run_id
@@ -249,7 +254,9 @@ class TestTaskRunStateTrigger:
         self, tenant_id, task_run_id, original_version
     ):
 
-        await models.TaskRun.where(id=task_run_id).update({"version": original_version})
+        await models.TaskRun.where(id=task_run_id).update(
+            {"version": original_version, "message": "original"}
+        )
         old_run = await models.TaskRun.where(id=task_run_id).first({"version"})
 
         dt = pendulum.now("UTC")
@@ -266,9 +273,13 @@ class TestTaskRunStateTrigger:
             serialized_state={"a": "b"},
         ).insert()
 
-        new_run = await models.TaskRun.where(id=task_run_id).first({"version"})
+        new_run = await models.TaskRun.where(id=task_run_id).first(
+            {"version", "state", "state_message"}
+        )
 
         assert new_run.version == 10
+        assert new_run.state_message == "x"
+        assert new_run.state == "z"
 
     async def test_trigger_updates_highest_version_when_multiple_states_inserted(
         self, tenant_id, task_run_id


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR modifies the trigger that updates run objects to ensure that it fires when the run has a null version or a version equal to the state being inserted. This can very rarely happen when the run was inserted with a manually-supplied version immediately prior to the state being inserted with the same version. It doesn't happen in application code but users could trip over it without this protection.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
