### PR TITLE
Increase number of max scheduled runs to 50

### DIFF
--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -556,7 +556,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
     """
 
     if max_runs is None:
-        max_runs = 10
+        max_runs = 50
 
     if flow_id is None:
         raise ValueError("Invalid flow id.")


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Increases the max number of scheduled runs from 10 -> 50



## Importance
<!-- Why is this PR important? -->
Gives the scheduler some breathing room when running over large numbers of flows.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [cc @cicdw] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
