### PR TITLE
Disable flow scheduling for unit tests

### DIFF
--- a/tests/fixtures/database_fixtures.py
+++ b/tests/fixtures/database_fixtures.py
@@ -1,11 +1,11 @@
 import datetime
 
 import pendulum
-import pytest
-
 import prefect
+import pytest
 from prefect import api, models
 from prefect.engine.state import Running, Submitted, Success
+
 from prefect_server import config
 
 START_TIME = pendulum.now()
@@ -61,7 +61,9 @@ async def flow_id(project_id):
     flow.add_task(prefect.Parameter("x", default=1))
 
     flow_id = await api.flows.create_flow(
-        project_id=project_id, serialized_flow=flow.serialize()
+        project_id=project_id,
+        serialized_flow=flow.serialize(),
+        set_schedule_active=False,
     )
 
     return flow_id

--- a/tests/services/test_scheduler.py
+++ b/tests/services/test_scheduler.py
@@ -1,12 +1,13 @@
 import pytest
-
 from prefect import api
 from prefect import models as m
+
 from prefect_server.services.towel.scheduler import Scheduler
 
 
 @pytest.fixture(autouse=True)
-async def clear_scheduled_runs(flow_id):
+async def setup(flow_id):
+    await api.flows.set_schedule_active(flow_id=flow_id)
     await m.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Tests go brrr



## Importance
<!-- Why is this PR important? -->
Scheduling 10 flows every single time a test runs is wasteful and adds up, even at a fraction of a second per test. This PR should cut test times by ~50%.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
