### PR TITLE
fix typo in helm notes

### DIFF
--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -45,7 +45,7 @@
   - The API location you retrieved in #2 should match this url
   - The default can be changed in the helm deployment at 'ui.apolloApiUrl' if it is incorrect
   - The location can also be changed within the UI itself per user
-  - The API must be accessible from the the user's machine for the UI to work
+  - The API must be accessible from the user's machine for the UI to work
 
 {{- if not .Values.jobs.createTenant.enabled }}
 


### PR DESCRIPTION
## Summary

Fixes grammatical mistake in the notes printed after `helm install prefecthq/prefect-server`.

I noticed this in the logs during @lauralorenz 's demo (https://www.youtube.com/watch?v=EwsMecjSYEU) 😀 

## Importance

Very minor grammatical fix. Just fixes a small grammatical error that might be distracting and might affect searches on this code.

## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)

Thanks for your time and consideration.