### PR TITLE
Helm ingress support

### DIFF
--- a/changes/pull229.yaml
+++ b/changes/pull229.yaml
@@ -1,0 +1,2 @@
+feature:
+  - "Add ingress support for `ui` and `apollo` components - [#229](https://github.com/PrefectHQ/server/pull/229)"

--- a/changes/pull229.yaml
+++ b/changes/pull229.yaml
@@ -1,4 +1,4 @@
 feature:
-  - "Add ingress support for `ui` and `apollo` components - [#229](https://github.com/PrefectHQ/server/pull/229)"
+  - "Helm: Add ingress support for `ui` and `apollo` components - [#229](https://github.com/PrefectHQ/server/pull/229)"
 contributor:
   - "[Augustinas Šimelionis](https://github.com/aaugustinas)"

--- a/changes/pull229.yaml
+++ b/changes/pull229.yaml
@@ -1,2 +1,4 @@
 feature:
   - "Add ingress support for `ui` and `apollo` components - [#229](https://github.com/PrefectHQ/server/pull/229)"
+contributor:
+  - "[Augustinas Šimelionis](https://github.com/aaugustinas)"

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -206,9 +206,7 @@ SET TIME ZONE 'UTC';
 
 ### Ingress
 
-If you have Ingress controller configured you might prefer to expose ouside traffic to services using Ingress rules.
-
-Ingress rule creation is suported for `ui` and `apollo` components of this chart.  
+Ingress rule creation is suported for `ui` and `apollo` components of this chart. You must have an Ingress controller (i.e. nginx) installed to your cluster and configured independently of this chart.
 
 To create an Ingress rule for a component,
 1. Disable direct service access by setting `<component>.service.type` to `ClusterIP` instead of `LoadBalancer`

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -210,7 +210,10 @@ If you have Ingress controller configured you might prefer to expose ouside traf
 
 Ingress rule creation is suported for `ui` and `apollo` components of this chart.  
 
-To create an Ingress rule resource set `service.type: ClusterIP` of the coresponding component and enable Ingress by setting `ingress.enables: true` and configuring list of hosts `ingress.hosts`. See configuration example in `values.yaml` file.  
+To create an Ingress rule for a component,
+1. Disable direct service access by setting `<component>.service.type` to `ClusterIP` instead of `LoadBalancer`
+2. Enable the Ingress by setting `<component>.ingress.enabled` to `true`
+3. Configuring the list of hosts at `<component>.ingress.hosts` to include your domains. _There is an example in values.yaml_ 
 
 Created component Ingress rules will be automatically configured to forward traffic from specified hosts to coresponding services.
 

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -82,8 +82,8 @@ The charts are hosted in a [Helm repository](https://helm.sh/docs/chart_reposito
 
     See [Helm install docs](https://helm.sh/docs/helm/helm_install/) for all options.
 
-
 #### Verifying package integrity
+
 _Checking package integrity is not required and is included as an optional security measure_
 
 The hosted charts are signed using GPG to ensure package integrity.
@@ -102,8 +102,6 @@ The hosted charts are signed using GPG to ensure package integrity.
     ```
 
 3. Add `--verify` to your installation and upgrade commands to verify package integrity
-
-
 
 ### Installing development versions
 
@@ -161,7 +159,6 @@ Development versions of the Helm chart will always be available directly from th
         --set jobs.createTenant.enabled=true
     ```
 
-
 #### Important notes about upgrading
 
 - Updates will only update infrastructure that is modified.
@@ -171,7 +168,6 @@ Development versions of the Helm chart will always be available directly from th
     ```
     $ helm upgrade ... --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD
     ```
-
 
 ## Options:
 
@@ -242,9 +238,10 @@ The chart `version` _must_ follow semantic versioning per Helm's standards and i
 The default `imagePullPolicy` is `Always` so images will be updated when your deployments are rolled over.
 This could result in some deployments being on mismatched versions which may not be guaranteed to work well together.
 
-##  Connecting to your Server
+## Connecting to your Server
 
 When you run `prefect backend server`, it configures the CLI to expect Server interactions rather than Prefect Cloud. By default, the CLI looks for the Server API at `localhost`. To connect the CLI to your newly deployed server, you'll either need to point the CLI to an external IP or forward the service to `localhost`
+
 ### Configure `prefect` to point to your service
 
 To designate your local `prefect` to point to the Kubernetes server,
@@ -263,7 +260,6 @@ To review the configuration file run `prefect config`.
 
 Alternatively, you can port-forward the apollo service to your localhost
 `kubectl port-forward svc/<APOLO-SERVICE> 4200:4200 -n <namespace>`.
-
 
 ## Troubleshooting
 

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -214,7 +214,7 @@ To create an Ingress rule resource set `service.type: ClusterIP` of the corespon
 
 Created component Ingress rules will be automatically configured to forward traffic from specified hosts to coresponding services.
 
-You can secure an Ingress by specifying a Secret that contains a TLS private key and certificate. For information how to create that secret refere to [official Kubernetes documentation - Ingress tls](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
+You can secure an Ingress by specifying a `Secret` that contains a TLS private key and certificate. For information how to setup the secret, refer to the [Ingress section of the official Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
 
 ## Versioning
 

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -178,6 +178,7 @@ Development versions of the Helm chart will always be available directly from th
 See comments in `values.yaml`.
 
 ### Tenant
+
 A tenant is needed for the server API to be operational.
 If there is no tenant in the database, the UI dashboard will fail to display and agents will error.
 
@@ -207,6 +208,18 @@ CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 SET TIME ZONE 'UTC';
 ```
 
+### Ingress
+
+If you have Ingress controller configured you might prefer to expose ouside traffic to services using Ingress rules.
+
+Ingress rule creation is suported for `ui` and `apollo` components of this chart.  
+
+To create an Ingress rule resource set `service.type: ClusterIP` of the coresponding component and enable Ingress by setting `ingress.enables: true` and configuring list of hosts `ingress.hosts`. See configuration example in `values.yaml` file.  
+
+Created component Ingress rules will be automatically configured to forward traffic from specified hosts to coresponding services.
+
+You can secure an Ingress by specifying a Secret that contains a TLS private key and certificate. For information how to create that secret refere to [official Kubernetes documentation - Ingress tls](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
+
 ## Versioning
 
 Released Helm charts have versions matching Prefect Server image tags.
@@ -220,7 +233,6 @@ These are set using `prefectVersionTag` and `uiVersionTag` which is pinned to th
 You may want to manage these version tags separately as Prefect Core and the UI are released more frequently than the Server.
 
 If using the agent in production, we recommend ensuring `prefectVersionTag` matches the version of Prefect you are using to ensure the agent matches your flow.
-
 
 ### Development
 

--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -16,7 +16,7 @@
 
 {{- else if .Values.ui.ingress.enabled -}}
 
-#1 The UI has been exposed using ingress:
+#1 The UI has been exposed using ingress and is available at the following hosts:
 
 {{- range .Values.ui.ingress.hosts }}
   http{{ if $.Values.ui.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ui.ingress.path }}

--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -14,6 +14,14 @@
   NOTE: It may take a few minutes for the LoadBalancer IP to be available. 
         You can watch the status of by running: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ $ui }}
 
+{{- else if .Values.ui.ingress.enabled -}}
+
+#1 The UI has been exposed using ingress:
+
+{{- range .Values.ui.ingress.hosts }}
+  http{{ if $.Values.ui.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ui.ingress.path }}
+{{- end }}
+
 {{- else -}}
 
 #1 The UI has been deployed as a non-default service type '{{ .Values.ui.service.type }}' and may not be immediately accessible.
@@ -34,7 +42,15 @@
   ) \
   && echo "API available at: http://$API_HOST:{{ .Values.apollo.service.port }}/graphql"
 
-{{- else }}
+{{- else if .Values.apollo.ingress.enabled -}}
+
+#2 The Apollo GraphQL API has been exposed using ingress:
+
+{{- range .Values.apollo.ingress.hosts }}
+  http{{ if $.Values.apollo.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.apollo.ingress.path }}
+{{- end }}
+
+{{- else -}}
 
 #2 The API has been deployed as a non-default service type '{{ .Values.apollo.service.type }}' and may not be immediately accessible.
    Please contact your Kubernetes administrator for help getting access.

--- a/helm/prefect-server/templates/NOTES.txt
+++ b/helm/prefect-server/templates/NOTES.txt
@@ -44,7 +44,7 @@
 
 {{- else if .Values.apollo.ingress.enabled -}}
 
-#2 The Apollo GraphQL API has been exposed using ingress:
+#2 The Apollo GraphQL API has been exposed using ingress and is available at the following hosts:
 
 {{- range .Values.apollo.ingress.hosts }}
   http{{ if $.Values.apollo.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.apollo.ingress.path }}

--- a/helm/prefect-server/templates/apollo/ingress.yaml
+++ b/helm/prefect-server/templates/apollo/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.apollo.ingress.enabled }}
+{{- $serviceName := include "prefect-server.nameField" (merge (dict "component" "apollo") .) -}}
+{{- $servicePort := .Values.apollo.service.port -}}
+{{- $ingressPath := .Values.apollo.ingress.path -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.apollo.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.apollo.ingress.annotations | indent 4 }}
+{{- end }}
+  labels: 
+    {{- include "prefect-server.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: apollo
+{{- if .Values.apollo.ingress.labels }}
+{{ toYaml .Values.apollo.ingress.labels | indent 4 }}
+{{- end }}
+spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+  {{- if .Values.apollo.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.apollo.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.apollo.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.apollo.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.apollo.ingress.tls | indent 4) . }}
+  {{- end -}}
+{{- end -}}

--- a/helm/prefect-server/templates/ui/ingress.yaml
+++ b/helm/prefect-server/templates/ui/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ui.ingress.enabled }}
+{{- $serviceName := include "prefect-server.nameField" (merge (dict "component" "ui") .) -}}
+{{- $servicePort := .Values.ui.service.port -}}
+{{- $ingressPath := .Values.ui.ingress.path -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.ui.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ui.ingress.annotations | indent 4 }}
+{{- end }}
+  labels: 
+    {{- include "prefect-server.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+{{- if .Values.ui.ingress.labels }}
+{{ toYaml .Values.ui.ingress.labels | indent 4 }}
+{{- end }}
+spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+  {{- if .Values.ui.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ui.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.ui.ingress.tls | indent 4) . }}
+  {{- end -}}
+{{- end -}}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -202,6 +202,30 @@ apollo:
     type: LoadBalancer
     port: 4200
 
+  ingress:
+    enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
+    annotations: {}
+    labels: {}
+
+    ## Hosts must be provided if Ingress is enabled.
+    hosts: []
+      # - prefecthq-apollo.domain.com
+
+    ## Path to use for ingress rules
+    path: /
+
+    ## TLS configuration for Prefect Ingress
+    ## Secret must be manually created in the namespace
+    tls: []
+    # - secretName: prefecthq-apollo-general-tls
+    #   hosts:
+    #   - prefecthq-apollo.example.com
+
   labels: {}
   annotations: {}
   replicas: 1
@@ -243,7 +267,7 @@ ui:
 
     annotations: {}
     labels: {}
-    
+
     ## Hosts must be provided if Ingress is enabled.
     hosts: []
       # - prefecthq-ui.domain.com

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -234,6 +234,30 @@ ui:
     type: LoadBalancer
     port: 8080
 
+  ingress:
+    enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
+    annotations: {}
+    labels: {}
+    
+    ## Hosts must be provided if Ingress is enabled.
+    hosts: []
+      # - prefecthq-ui.domain.com
+
+    ## Path to use for ingress rules
+    path: /
+
+    ## TLS configuration for Prefect Ingress
+    ## Secret must be manually created in the namespace
+    tls: []
+    # - secretName: prefecthq-ui-general-tls
+    #   hosts:
+    #   - prefecthq-ui.example.com
+
   labels: {}
   annotations: {}
   replicas: 1


### PR DESCRIPTION
## Summary
Add ingress support for `ui` and `apollo` components in helm chart.

## Importance
Many teams use ingress to expose services outside of kubernetes.

## Checklist

This PR:

- [ ] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
