### PR TITLE
Schedule flow runs concurrently

### DIFF
--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -636,7 +636,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
             idempotency_key = f"auto-scheduled:{event.start_time.in_tz('UTC')}"
 
         schedule_coros.append(
-            await api.runs.create_flow_run(
+            api.runs.create_flow_run(
                 flow_id=flow_id,
                 scheduled_start_time=event.start_time,
                 parameters=event.parameter_defaults,
@@ -646,7 +646,7 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
         )
 
     # schedule runs concurrently
-    await asyncio.gather(*schedule_coros)
+    run_ids.extend(await asyncio.gather(*schedule_coros))
 
     await models.FlowRun.where({"id": {"_in": run_ids}}).update(
         set={"auto_scheduled": True}

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -7,12 +7,12 @@ from typing import Any, Dict, List
 
 import pendulum
 from packaging import version as module_version
-from pydantic import BaseModel, Field, validator
-
 from prefect import api, models
 from prefect.serialization.schedule import ScheduleSchema
-from prefect.utilities.graphql import with_args, EnumValue
+from prefect.utilities.graphql import EnumValue, with_args
 from prefect.utilities.plugins import register_api
+from pydantic import BaseModel, Field, validator
+
 from prefect_server import config
 from prefect_server.utilities import logging
 
@@ -614,6 +614,8 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
     else:
         last_scheduled_run = pendulum.now("UTC")
 
+    schedule_coros = []
+
     # schedule every event with an idempotent flow run
     for event in flow_schedule.next(n=max_runs, return_events=True):
 
@@ -633,19 +635,18 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
         else:
             idempotency_key = f"auto-scheduled:{event.start_time.in_tz('UTC')}"
 
-        run_id = await api.runs.create_flow_run(
-            flow_id=flow_id,
-            scheduled_start_time=event.start_time,
-            parameters=event.parameter_defaults,
-            labels=event.labels,
-            idempotency_key=idempotency_key,
+        schedule_coros.append(
+            await api.runs.create_flow_run(
+                flow_id=flow_id,
+                scheduled_start_time=event.start_time,
+                parameters=event.parameter_defaults,
+                labels=event.labels,
+                idempotency_key=idempotency_key,
+            )
         )
 
-        logger.debug(
-            f"Flow run {run_id} of flow {flow_id} scheduled for {event.start_time}"
-        )
-
-        run_ids.append(run_id)
+    # schedule runs concurrently
+    await asyncio.gather(*schedule_coros)
 
     await models.FlowRun.where({"id": {"_in": run_ids}}).update(
         set={"auto_scheduled": True}

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -2,15 +2,17 @@ import datetime
 from typing import Any, Iterable, List
 
 import pendulum
-
 import prefect
 from prefect import api, models
 from prefect.engine.state import Pending, Queued, Scheduled
+from prefect.utilities import logging
 from prefect.utilities.graphql import EnumValue
 from prefect.utilities.plugins import register_api
+
 from prefect_server import config
 from prefect_server.utilities import exceptions, names
 
+logger = logging.get_logger("api.runs")
 
 SCHEDULED_STATES = [
     s.__name__
@@ -239,6 +241,10 @@ async def _create_flow_run(
 
     # apply the flow run's initial state via `set_flow_run_state`
     await api.states.set_flow_run_state(flow_run_id=flow_run_id, state=state)
+
+    logger.debug(
+        f"Flow run {flow_run_id} of flow {flow_id or flow.id} scheduled for {scheduled_start_time}"
+    )
 
     return flow_run_id
 

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1041,7 +1041,8 @@ class TestSetScheduleActive:
         flow = await models.Flow.where(id=flow_id).first({"is_schedule_active"})
         assert flow.is_schedule_active is True
 
-    async def test_set_schedule_active_schedules_new_runs(self, flow_id):
+    @pytest.mark.parametrize("x", range(5))
+    async def test_set_schedule_active_schedules_new_runs(self, flow_id, x):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -1041,8 +1041,7 @@ class TestSetScheduleActive:
         flow = await models.Flow.where(id=flow_id).first({"is_schedule_active"})
         assert flow.is_schedule_active is True
 
-    @pytest.mark.parametrize("x", range(5))
-    async def test_set_schedule_active_schedules_new_runs(self, flow_id, x):
+    async def test_set_schedule_active_schedules_new_runs(self, flow_id):
         await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).delete()
         assert await models.FlowRun.where({"flow_id": {"_eq": flow_id}}).count() == 0
 


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Scheduling runs concurrently instead of serially speeds up scheduling by ~25%



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
