### PR TITLE
Update `LoopServices` to use the config to specify loop times

### DIFF
--- a/changes/pr235.yaml
+++ b/changes/pr235.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Update `LoopServices` to use the config to specify loop times - [#235](https://github.com/PrefectHQ/server/pull/235)"

--- a/services/hasura/migrations/metadata.yaml
+++ b/services/hasura/migrations/metadata.yaml
@@ -1,50 +1,73 @@
-version: 2
+functions:
+- function:
+    name: downstream_tasks
+    schema: utility
+- function:
+    name: upstream_tasks
+    schema: utility
 tables:
-- table:
-    schema: public
-    name: agent
-  object_relationships:
-  - name: agent_config
-    using:
-      foreign_key_constraint_on: agent_config_id
-  array_relationships:
-  - name: flow_runs
-    using:
-      foreign_key_constraint_on:
-        column: agent_id
-        table:
-          schema: public
-          name: flow_run
-- table:
-    schema: public
-    name: agent_config
-  array_relationships:
+- array_relationships:
   - name: agents
     using:
       foreign_key_constraint_on:
         column: agent_config_id
         table:
-          schema: public
           name: agent
-- table:
+          schema: public
+  table:
+    name: agent_config
     schema: public
-    name: cloud_hook
-- table:
-    schema: public
-    name: edge
-  object_relationships:
-  - name: downstream_task
+- array_relationships:
+  - name: downstream_edges
     using:
-      foreign_key_constraint_on: downstream_task_id
+      foreign_key_constraint_on:
+        column: upstream_task_id
+        table:
+          name: edge
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          name: task_run
+          schema: public
+  - name: upstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: downstream_task_id
+        table:
+          name: edge
+          schema: public
+  object_relationships:
   - name: flow
     using:
       foreign_key_constraint_on: flow_id
-  - name: upstream_task
-    using:
-      foreign_key_constraint_on: upstream_task_id
-- table:
+  table:
+    name: task
     schema: public
-    name: flow
+- array_relationships:
+  - name: edges
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: edge
+          schema: public
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_run
+          schema: public
+  - name: tasks
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: task
+          schema: public
   object_relationships:
   - name: flow_group
     using:
@@ -55,46 +78,101 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  array_relationships:
-  - name: edges
+  table:
+    name: flow
+    schema: public
+- array_relationships:
+  - name: flow_groups
     using:
       foreign_key_constraint_on:
-        column: flow_id
+        column: tenant_id
         table:
+          name: flow_group
           schema: public
-          name: edge
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow
+          schema: public
+  - name: projects
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: project
+          schema: public
+  table:
+    name: tenant
+    schema: public
+- array_relationships:
   - name: flow_runs
     using:
       foreign_key_constraint_on:
-        column: flow_id
+        column: agent_id
         table:
-          schema: public
           name: flow_run
-  - name: tasks
-    using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
           schema: public
-          name: task
-- table:
-    schema: public
-    name: flow_group
   object_relationships:
-  - name: tenant
+  - name: agent_config
     using:
-      foreign_key_constraint_on: tenant_id
-  array_relationships:
+      foreign_key_constraint_on: agent_config_id
+  table:
+    name: agent
+    schema: public
+- array_relationships:
   - name: flows
     using:
       foreign_key_constraint_on:
         column: flow_group_id
         table:
-          schema: public
           name: flow
-- table:
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_group
     schema: public
-    name: flow_run
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: project
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: flow_run_state
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: task_run
+          schema: public
   object_relationships:
   - name: agent
     using:
@@ -105,88 +183,24 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  array_relationships:
+  table:
+    name: flow_run
+    schema: public
+- array_relationships:
   - name: logs
     using:
       foreign_key_constraint_on:
-        column: flow_run_id
+        column: task_run_id
         table:
-          schema: public
           name: log
+          schema: public
   - name: states
     using:
       foreign_key_constraint_on:
-        column: flow_run_id
+        column: task_run_id
         table:
+          name: task_run_state
           schema: public
-          name: flow_run_state
-  - name: task_runs
-    using:
-      foreign_key_constraint_on:
-        column: flow_run_id
-        table:
-          schema: public
-          name: task_run
-- table:
-    schema: public
-    name: flow_run_state
-  object_relationships:
-  - name: flow_run
-    using:
-      foreign_key_constraint_on: flow_run_id
-- table:
-    schema: public
-    name: log
-- table:
-    schema: public
-    name: message
-- table:
-    schema: public
-    name: project
-  object_relationships:
-  - name: tenant
-    using:
-      foreign_key_constraint_on: tenant_id
-  array_relationships:
-  - name: flows
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          schema: public
-          name: flow
-- table:
-    schema: public
-    name: task
-  object_relationships:
-  - name: flow
-    using:
-      foreign_key_constraint_on: flow_id
-  array_relationships:
-  - name: downstream_edges
-    using:
-      foreign_key_constraint_on:
-        column: upstream_task_id
-        table:
-          schema: public
-          name: edge
-  - name: task_runs
-    using:
-      foreign_key_constraint_on:
-        column: task_id
-        table:
-          schema: public
-          name: task_run
-  - name: upstream_edges
-    using:
-      foreign_key_constraint_on:
-        column: downstream_task_id
-        table:
-          schema: public
-          name: edge
-- table:
-    schema: public
-    name: task_run
   object_relationships:
   - name: flow_run
     using:
@@ -197,76 +211,62 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  array_relationships:
-  - name: logs
-    using:
-      foreign_key_constraint_on:
-        column: task_run_id
-        table:
-          schema: public
-          name: log
-  - name: states
-    using:
-      foreign_key_constraint_on:
-        column: task_run_id
-        table:
-          schema: public
-          name: task_run_state
-- table:
+  table:
+    name: task_run
     schema: public
-    name: task_run_artifact
-  object_relationships:
-  - name: task_run
+- object_relationships:
+  - name: downstream_task
     using:
-      foreign_key_constraint_on: task_run_id
-- table:
+      foreign_key_constraint_on: downstream_task_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+  table:
+    name: edge
     schema: public
-    name: task_run_state
-  object_relationships:
-  - name: task_run
+- object_relationships:
+  - name: flow_run
     using:
-      foreign_key_constraint_on: task_run_id
-- table:
+      foreign_key_constraint_on: flow_run_id
+  table:
+    name: flow_run_state
     schema: public
-    name: tenant
-  array_relationships:
-  - name: flow_groups
-    using:
-      foreign_key_constraint_on:
-        column: tenant_id
-        table:
-          schema: public
-          name: flow_group
-  - name: flows
-    using:
-      foreign_key_constraint_on:
-        column: tenant_id
-        table:
-          schema: public
-          name: flow
-  - name: projects
-    using:
-      foreign_key_constraint_on:
-        column: tenant_id
-        table:
-          schema: public
-          name: project
-- table:
-    schema: utility
-    name: traversal
-  object_relationships:
+- object_relationships:
   - name: task
     using:
       manual_configuration:
-        remote_table:
-          schema: public
-          name: task
         column_mapping:
           task_id: id
-functions:
-- function:
+        remote_table:
+          name: task
+          schema: public
+  table:
+    name: traversal
     schema: utility
-    name: downstream_tasks
-- function:
-    schema: utility
-    name: upstream_tasks
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_artifact
+    schema: public
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_state
+    schema: public
+- table:
+    name: cloud_hook
+    schema: public
+- table:
+    name: log
+    schema: public
+- table:
+    name: message
+    schema: public
+version: 2

--- a/services/hasura/migrations/metadata.yaml
+++ b/services/hasura/migrations/metadata.yaml
@@ -1,73 +1,50 @@
-functions:
-- function:
-    name: downstream_tasks
-    schema: utility
-- function:
-    name: upstream_tasks
-    schema: utility
+version: 2
 tables:
-- array_relationships:
+- table:
+    schema: public
+    name: agent
+  object_relationships:
+  - name: agent_config
+    using:
+      foreign_key_constraint_on: agent_config_id
+  array_relationships:
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: agent_id
+        table:
+          schema: public
+          name: flow_run
+- table:
+    schema: public
+    name: agent_config
+  array_relationships:
   - name: agents
     using:
       foreign_key_constraint_on:
         column: agent_config_id
         table:
+          schema: public
           name: agent
-          schema: public
-  table:
-    name: agent_config
+- table:
     schema: public
-- array_relationships:
-  - name: downstream_edges
-    using:
-      foreign_key_constraint_on:
-        column: upstream_task_id
-        table:
-          name: edge
-          schema: public
-  - name: task_runs
-    using:
-      foreign_key_constraint_on:
-        column: task_id
-        table:
-          name: task_run
-          schema: public
-  - name: upstream_edges
-    using:
-      foreign_key_constraint_on:
-        column: downstream_task_id
-        table:
-          name: edge
-          schema: public
+    name: cloud_hook
+- table:
+    schema: public
+    name: edge
   object_relationships:
+  - name: downstream_task
+    using:
+      foreign_key_constraint_on: downstream_task_id
   - name: flow
     using:
       foreign_key_constraint_on: flow_id
-  table:
-    name: task
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+- table:
     schema: public
-- array_relationships:
-  - name: edges
-    using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
-          name: edge
-          schema: public
-  - name: flow_runs
-    using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
-          name: flow_run
-          schema: public
-  - name: tasks
-    using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
-          name: task
-          schema: public
+    name: flow
   object_relationships:
   - name: flow_group
     using:
@@ -78,101 +55,46 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  table:
-    name: flow
-    schema: public
-- array_relationships:
-  - name: flow_groups
+  array_relationships:
+  - name: edges
     using:
       foreign_key_constraint_on:
-        column: tenant_id
+        column: flow_id
         table:
-          name: flow_group
           schema: public
-  - name: flows
-    using:
-      foreign_key_constraint_on:
-        column: tenant_id
-        table:
-          name: flow
-          schema: public
-  - name: projects
-    using:
-      foreign_key_constraint_on:
-        column: tenant_id
-        table:
-          name: project
-          schema: public
-  table:
-    name: tenant
-    schema: public
-- array_relationships:
+          name: edge
   - name: flow_runs
     using:
       foreign_key_constraint_on:
-        column: agent_id
+        column: flow_id
         table:
-          name: flow_run
           schema: public
-  object_relationships:
-  - name: agent_config
+          name: flow_run
+  - name: tasks
     using:
-      foreign_key_constraint_on: agent_config_id
-  table:
-    name: agent
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          schema: public
+          name: task
+- table:
     schema: public
-- array_relationships:
+    name: flow_group
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  array_relationships:
   - name: flows
     using:
       foreign_key_constraint_on:
         column: flow_group_id
         table:
+          schema: public
           name: flow
-          schema: public
-  object_relationships:
-  - name: tenant
-    using:
-      foreign_key_constraint_on: tenant_id
-  table:
-    name: flow_group
+- table:
     schema: public
-- array_relationships:
-  - name: flows
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          name: flow
-          schema: public
-  object_relationships:
-  - name: tenant
-    using:
-      foreign_key_constraint_on: tenant_id
-  table:
-    name: project
-    schema: public
-- array_relationships:
-  - name: logs
-    using:
-      foreign_key_constraint_on:
-        column: flow_run_id
-        table:
-          name: log
-          schema: public
-  - name: states
-    using:
-      foreign_key_constraint_on:
-        column: flow_run_id
-        table:
-          name: flow_run_state
-          schema: public
-  - name: task_runs
-    using:
-      foreign_key_constraint_on:
-        column: flow_run_id
-        table:
-          name: task_run
-          schema: public
+    name: flow_run
   object_relationships:
   - name: agent
     using:
@@ -183,24 +105,88 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  table:
-    name: flow_run
-    schema: public
-- array_relationships:
+  array_relationships:
   - name: logs
     using:
       foreign_key_constraint_on:
-        column: task_run_id
+        column: flow_run_id
         table:
-          name: log
           schema: public
+          name: log
   - name: states
     using:
       foreign_key_constraint_on:
-        column: task_run_id
+        column: flow_run_id
         table:
-          name: task_run_state
           schema: public
+          name: flow_run_state
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          schema: public
+          name: task_run
+- table:
+    schema: public
+    name: flow_run_state
+  object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+- table:
+    schema: public
+    name: log
+- table:
+    schema: public
+    name: message
+- table:
+    schema: public
+    name: project
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          schema: public
+          name: flow
+- table:
+    schema: public
+    name: task
+  object_relationships:
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  array_relationships:
+  - name: downstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: upstream_task_id
+        table:
+          schema: public
+          name: edge
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          schema: public
+          name: task_run
+  - name: upstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: downstream_task_id
+        table:
+          schema: public
+          name: edge
+- table:
+    schema: public
+    name: task_run
   object_relationships:
   - name: flow_run
     using:
@@ -211,62 +197,76 @@ tables:
   - name: tenant
     using:
       foreign_key_constraint_on: tenant_id
-  table:
-    name: task_run
+  array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          schema: public
+          name: log
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          schema: public
+          name: task_run_state
+- table:
     schema: public
-- object_relationships:
-  - name: downstream_task
+    name: task_run_artifact
+  object_relationships:
+  - name: task_run
     using:
-      foreign_key_constraint_on: downstream_task_id
-  - name: flow
-    using:
-      foreign_key_constraint_on: flow_id
-  - name: upstream_task
-    using:
-      foreign_key_constraint_on: upstream_task_id
-  table:
-    name: edge
+      foreign_key_constraint_on: task_run_id
+- table:
     schema: public
-- object_relationships:
-  - name: flow_run
+    name: task_run_state
+  object_relationships:
+  - name: task_run
     using:
-      foreign_key_constraint_on: flow_run_id
-  table:
-    name: flow_run_state
+      foreign_key_constraint_on: task_run_id
+- table:
     schema: public
-- object_relationships:
+    name: tenant
+  array_relationships:
+  - name: flow_groups
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          schema: public
+          name: flow_group
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          schema: public
+          name: flow
+  - name: projects
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          schema: public
+          name: project
+- table:
+    schema: utility
+    name: traversal
+  object_relationships:
   - name: task
     using:
       manual_configuration:
+        remote_table:
+          schema: public
+          name: task
         column_mapping:
           task_id: id
-        remote_table:
-          name: task
-          schema: public
-  table:
-    name: traversal
+functions:
+- function:
     schema: utility
-- object_relationships:
-  - name: task_run
-    using:
-      foreign_key_constraint_on: task_run_id
-  table:
-    name: task_run_artifact
-    schema: public
-- object_relationships:
-  - name: task_run
-    using:
-      foreign_key_constraint_on: task_run_id
-  table:
-    name: task_run_state
-    schema: public
-- table:
-    name: cloud_hook
-    schema: public
-- table:
-    name: log
-    schema: public
-- table:
-    name: message
-    schema: public
-version: 2
+    name: downstream_tasks
+- function:
+    schema: utility
+    name: upstream_tasks

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -73,11 +73,14 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
     disable_access_logs = false
 
     [services.scheduler]
-    # run scheduler every 5 minutes
-    scheduler_loop_seconds = 300
+    loop_seconds = 300
 
     [services.lazarus]
     resurrection_attempt_limit = 3
+
+    [services.zombiekiller]
+    loop_seconds = 120
+    
 
 
 # UI Colors corresponding to run states

--- a/src/prefect_server/configuration.py
+++ b/src/prefect_server/configuration.py
@@ -14,4 +14,8 @@ ENV_VAR_PREFIX = "PREFECT_SERVER"
 config = load_configuration(
     path=DEFAULT_CONFIG, user_config_path=USER_CONFIG, env_var_prefix=ENV_VAR_PREFIX
 )
-register_plugin("backend_config", config)
+
+
+@register_plugin("get_backend_config")
+def get_backend_config(): 
+    return config

--- a/src/prefect_server/configuration.py
+++ b/src/prefect_server/configuration.py
@@ -2,6 +2,7 @@ import os
 
 import prefect_server
 from prefect.configuration import load_configuration
+from prefect.utilities.plugins import register_plugin
 
 DEFAULT_CONFIG = os.path.join(os.path.dirname(prefect_server.__file__), "config.toml")
 USER_CONFIG = os.getenv(
@@ -13,3 +14,4 @@ ENV_VAR_PREFIX = "PREFECT_SERVER"
 config = load_configuration(
     path=DEFAULT_CONFIG, user_config_path=USER_CONFIG, env_var_prefix=ENV_VAR_PREFIX
 )
+register_plugin("backend_config", config)

--- a/src/prefect_server/configuration.py
+++ b/src/prefect_server/configuration.py
@@ -17,5 +17,5 @@ config = load_configuration(
 
 
 @register_plugin("get_backend_config")
-def get_backend_config(): 
+def get_backend_config():
     return config

--- a/src/prefect_server/services/loop_service.py
+++ b/src/prefect_server/services/loop_service.py
@@ -5,7 +5,8 @@ from typing import Union
 
 import pendulum
 
-from prefect_server import config, utilities
+import prefect
+from prefect_server import utilities
 
 
 class LoopService:
@@ -32,12 +33,16 @@ class LoopService:
 
                 # split the key on '.' and recurse
                 split_keys = self.loop_seconds_config_key.split(".")
-                cfg = config
+
+                # Load the current backend config
+                cfg = prefect.plugins.backend_config
                 for key in split_keys[:-1]:
                     cfg = cfg.get(key, {})
+
                 loop_seconds = cfg.get(split_keys[-1])
             else:
                 loop_seconds = self.loop_seconds_default
+
         if loop_seconds == 0:
             raise ValueError("`loop_seconds` must be greater than 0.")
 

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -21,7 +21,6 @@ LAZARUS_EXCLUDE = [
 
 
 class Lazarus(LoopService):
-    
     async def run_once(self) -> None:
         """
         The Lazarus process revives any flow runs that are submitted or running but have no tasks in

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -21,9 +21,7 @@ LAZARUS_EXCLUDE = [
 
 
 class Lazarus(LoopService):
-
-    loop_seconds_default = 600
-
+    
     async def run_once(self) -> None:
         """
         The Lazarus process revives any flow runs that are submitted or running but have no tasks in

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -14,8 +14,6 @@ class Scheduler(LoopService):
         - the schedule is active
         - the flow is not archived
     """
-
-    loop_seconds_config_key = "services.scheduler.scheduler_loop_seconds"
     loop_seconds_default = 150
 
     async def run_once(self) -> int:

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -14,6 +14,7 @@ class Scheduler(LoopService):
         - the schedule is active
         - the flow is not archived
     """
+
     loop_seconds_default = 150
 
     async def run_once(self) -> int:

--- a/tests/services/test_loop_service.py
+++ b/tests/services/test_loop_service.py
@@ -2,6 +2,8 @@ import asyncio
 import pytest
 
 from prefect_server.services.loop_service import LoopService
+from prefect_server.utilities.tests import set_temporary_config
+
 
 COUNTER = 0
 
@@ -13,6 +15,13 @@ class LoopServiceTest(LoopService):
         global COUNTER
         COUNTER += 1
         print(COUNTER)
+
+
+async def test_loop_service_uses_config_key():
+    with set_temporary_config("services.loopservicetest.loop_seconds", 10):
+        ls = LoopServiceTest()
+
+    assert ls.loop_seconds == 10
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This appears to be a necessary first step for tightening loop service times to reduce service test failures in CI. Once we're using the config instead of 'loop_seconds_default' then we can set a config for CI that uses faster loop times. This will require changes in Cloud as well.

- Adds `get_backend_config()` plugin so we can load the config across Server/Cloud
- Adds default config key inference and precedence to `LoopService` config key loading


## Importance
<!-- Why is this PR important? -->

Improve test times and reduce timeout failures in Cloud https://github.com/PrefectHQ/cloud/issues/3065


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
