### PR TITLE
Log `set_schedule_active` failure while creating a flow

### DIFF
--- a/changes/pr236.yaml
+++ b/changes/pr236.yaml
@@ -1,0 +1,3 @@
+
+fix:
+  - "Log `set_schedule_active` failure while creating a flow - [#236](https://github.com/PrefectHQ/server/pull/236)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -305,7 +305,6 @@ async def create_flow(
                 "(flow_id={flow_id}).",
                 exc_info=True,
             )
-            pass
 
     return flow_id
 

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -299,7 +299,12 @@ async def create_flow(
         # from kicking in
         try:
             await api.flows.set_schedule_active(flow_id=flow_id)
-        except ValueError:
+        except Exception:
+            logger.error(
+                "Failed to set schedule to active while creating flow "
+                "(flow_id={flow_id}).",
+                exc_info=True,
+            )
             pass
 
     return flow_id


### PR DESCRIPTION
## Importance
<!-- Why is this PR important? -->

A try/except/pass does not have a log associated with it in the backend

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
