### PR TITLE
Include serialized_hash in the flow table for lookups

### DIFF
--- a/changes/pr245.yaml
+++ b/changes/pr245.yaml
@@ -1,0 +1,3 @@
+
+enhancement:
+  - "Include serialized_hash in the flow table for lookups - [#245](https://github.com/PrefectHQ/server/pull/245)"

--- a/services/hasura/migrations/versions/metadata-e0e276cd1ec9.yaml
+++ b/services/hasura/migrations/versions/metadata-e0e276cd1ec9.yaml
@@ -1,0 +1,272 @@
+functions:
+- function:
+    name: downstream_tasks
+    schema: utility
+- function:
+    name: upstream_tasks
+    schema: utility
+tables:
+- array_relationships:
+  - name: agents
+    using:
+      foreign_key_constraint_on:
+        column: agent_config_id
+        table:
+          name: agent
+          schema: public
+  table:
+    name: agent_config
+    schema: public
+- array_relationships:
+  - name: downstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: upstream_task_id
+        table:
+          name: edge
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: task_id
+        table:
+          name: task_run
+          schema: public
+  - name: upstream_edges
+    using:
+      foreign_key_constraint_on:
+        column: downstream_task_id
+        table:
+          name: edge
+          schema: public
+  object_relationships:
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  table:
+    name: task
+    schema: public
+- array_relationships:
+  - name: edges
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: edge
+          schema: public
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_run
+          schema: public
+  - name: tasks
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: task
+          schema: public
+  object_relationships:
+  - name: flow_group
+    using:
+      foreign_key_constraint_on: flow_group_id
+  - name: project
+    using:
+      foreign_key_constraint_on: project_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow
+    schema: public
+- array_relationships:
+  - name: flow_groups
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow_group
+          schema: public
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: flow
+          schema: public
+  - name: projects
+    using:
+      foreign_key_constraint_on:
+        column: tenant_id
+        table:
+          name: project
+          schema: public
+  table:
+    name: tenant
+    schema: public
+- array_relationships:
+  - name: flow_runs
+    using:
+      foreign_key_constraint_on:
+        column: agent_id
+        table:
+          name: flow_run
+          schema: public
+  object_relationships:
+  - name: agent_config
+    using:
+      foreign_key_constraint_on: agent_config_id
+  table:
+    name: agent
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: flow_group_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_group
+    schema: public
+- array_relationships:
+  - name: flows
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          name: flow
+          schema: public
+  object_relationships:
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: project
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: flow_run_state
+          schema: public
+  - name: task_runs
+    using:
+      foreign_key_constraint_on:
+        column: flow_run_id
+        table:
+          name: task_run
+          schema: public
+  object_relationships:
+  - name: agent
+    using:
+      foreign_key_constraint_on: agent_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: flow_run
+    schema: public
+- array_relationships:
+  - name: logs
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: log
+          schema: public
+  - name: states
+    using:
+      foreign_key_constraint_on:
+        column: task_run_id
+        table:
+          name: task_run_state
+          schema: public
+  object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  - name: task
+    using:
+      foreign_key_constraint_on: task_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+  table:
+    name: task_run
+    schema: public
+- object_relationships:
+  - name: downstream_task
+    using:
+      foreign_key_constraint_on: downstream_task_id
+  - name: flow
+    using:
+      foreign_key_constraint_on: flow_id
+  - name: upstream_task
+    using:
+      foreign_key_constraint_on: upstream_task_id
+  table:
+    name: edge
+    schema: public
+- object_relationships:
+  - name: flow_run
+    using:
+      foreign_key_constraint_on: flow_run_id
+  table:
+    name: flow_run_state
+    schema: public
+- object_relationships:
+  - name: task
+    using:
+      manual_configuration:
+        column_mapping:
+          task_id: id
+        remote_table:
+          name: task
+          schema: public
+  table:
+    name: traversal
+    schema: utility
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_artifact
+    schema: public
+- object_relationships:
+  - name: task_run
+    using:
+      foreign_key_constraint_on: task_run_id
+  table:
+    name: task_run_state
+    schema: public
+- table:
+    name: cloud_hook
+    schema: public
+- table:
+    name: log
+    schema: public
+- table:
+    name: message
+    schema: public
+version: 2

--- a/services/postgres/alembic/versions/2021-04-19T133758_add_flow_serialized_hash.py
+++ b/services/postgres/alembic/versions/2021-04-19T133758_add_flow_serialized_hash.py
@@ -1,0 +1,29 @@
+"""
+Add 'Flow.serialized_hash'
+
+Revision ID: e0e276cd1ec9
+Revises: a666a3f4e422
+Create Date: 2021-04-19 13:37:58.897204
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "e0e276cd1ec9"
+down_revision = "a666a3f4e422"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow",
+        sa.Column("serialized_hash", sa.String, nullable=True, index=True),
+    )
+
+
+def downgrade():
+    op.drop_column("flow", "serialized_hash")

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List
 import pendulum
 from packaging import version as module_version
 from prefect import api, models
-from prefect.serialization.flow import FlowSchema as CoreFlowSchema
 from prefect.serialization.schedule import ScheduleSchema
 from prefect.utilities.graphql import EnumValue, with_args
 from prefect.utilities.plugins import register_api

--- a/src/prefect_server/database/models.py
+++ b/src/prefect_server/database/models.py
@@ -60,6 +60,7 @@ class Flow(HasuraModel):
     name: str = None
     description: str = None
     serialized_flow: Dict[str, Any] = None
+    serialized_hash: str = None
     environment: Dict[str, Any] = None
     run_config: Dict[str, Any] = None
     storage: Dict[str, Any] = None

--- a/tests/api/test_flows.py
+++ b/tests/api/test_flows.py
@@ -48,10 +48,18 @@ class TestFlowModels:
 
 class TestCreateFlow:
     async def test_create_flow(self, project_id, flow):
+        serialized_flow = flow.serialize()
+        serialized_hash = flow.serialized_hash()
+
         flow_id = await api.flows.create_flow(
-            project_id=project_id, serialized_flow=flow.serialize()
+            project_id=project_id, serialized_flow=serialized_flow
         )
-        assert await models.Flow.where(id=flow_id).first()
+        db_flow = await models.Flow.where(id=flow_id).first(
+            {"serialized_flow", "serialized_hash"}
+        )
+
+        assert db_flow.serialized_hash == serialized_hash
+        assert db_flow.serialized_flow == serialized_flow
 
     async def test_create_flow_with_no_schedule_sets_schedule_inactive(
         self, project_id, flow


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

I'd like to be able to check if a flow has already been registered by looking up the unique hash for the serialized flow. This would allow us to retrieve a flow id for a flow object without requiring registration on every script run or providing a `flow_id` in the context. If your local flow object matches the serialized hash of an unarchived flow in the backend, we can start a flow run using your local object without registering a new one.


## Importance
<!-- Why is this PR important? -->

Provides a path to a simpler API for https://github.com/PrefectHQ/prefect/pull/4301

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
