### PR TITLE
Expose kwargs in create_logs and write immediately from services

### DIFF
--- a/changes/pr247.yaml
+++ b/changes/pr247.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Introduce **kwargs to `create_logs` for Cloud compatibility - [#247](https://github.com/PrefectHQ/server/pull/247)"

--- a/src/prefect_server/api/logs.py
+++ b/src/prefect_server/api/logs.py
@@ -9,9 +9,10 @@ from prefect.utilities.plugins import register_api
 
 
 @register_api("logs.create_logs")
-async def create_logs(logs: List[Dict[str, Any]]) -> str:
+async def create_logs(logs: List[Dict[str, Any]], **kwargs) -> str:
     """
     Inserts log record(s) into the database.
+
     Args:
         - logs (list): a list of log records represented as dictionaries, containing the following keys:
             `tenant_id` and `flow_run_id` and optionally containing task_run_id, timestamp, message, name, level and info.

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -124,7 +124,8 @@ class Lazarus(LoopService):
                                 ),
                                 level="INFO",
                             )
-                        ]
+                        ],
+                        defer_db_write=False,
                     )
 
                     run_count += 1
@@ -159,7 +160,8 @@ class Lazarus(LoopService):
                             message=message,
                             level="ERROR",
                         )
-                    ]
+                    ],
+                    defer_db_write=False,
                 )
 
         if run_count:

--- a/src/prefect_server/services/towel/zombie_killer.py
+++ b/src/prefect_server/services/towel/zombie_killer.py
@@ -78,7 +78,8 @@ class ZombieKiller(LoopService):
                             message=message,
                             level="ERROR",
                         )
-                    ]
+                    ],
+                    defer_db_write=False,
                 )
 
                 zombies += 1
@@ -196,7 +197,8 @@ class ZombieKiller(LoopService):
                             message=message,
                             level="ERROR",
                         )
-                    ]
+                    ],
+                    defer_db_write=False,
                 )
 
                 zombies += 1


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
This PR is a no-op from the perspective of Server - it allows for arbitrary `**kwargs` to be passed to `create_logs` so that services that call this function can declare that they want the logs written immediately.



## Importance
<!-- Why is this PR important? -->
For better compatibility between Server and Cloud in the backend.  **cc:** @mashun4ek 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
