### PR TITLE
Decrease task/edge batch insertion size

### DIFF
--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -272,7 +272,7 @@ async def create_flow(
     ).insert()
 
     try:
-        batch_insertion_size = 2500
+        batch_insertion_size = 1000
 
         for tasks_chunk in chunked_iterable(flow.tasks, batch_insertion_size):
             await models.Task.insert_many(


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Decrease batch size for task / edge insertion.


## Importance
<!-- Why is this PR important? -->
Flows with large numbers of edges and tasks can timeout.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[] adds new tests (if appropriate)~
- ~[ ] adds a change file in the `changes/` directory (if appropriate)~
