### PR TITLE
Use flow-defined required default parameters when creating a run

### DIFF
--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -160,7 +160,8 @@ async def create_flow_run(
             run_config = flow.run_config
 
     # check parameters
-    run_parameters = flow.flow_group.default_parameters
+    run_parameters = { p["name"]: p["default"] for p in flow.parameters }
+    run_parameters.update((flow.flow_group.default_parameters or {}))
     run_parameters.update((parameters or {}))
     required_parameters = [p["name"] for p in flow.parameters if p["required"]]
     missing = set(required_parameters).difference(run_parameters)

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -160,7 +160,7 @@ async def create_flow_run(
             run_config = flow.run_config
 
     # check parameters
-    run_parameters = { p["name"]: p["default"] for p in flow.parameters }
+    run_parameters = {p["name"]: p["default"] for p in flow.parameters}
     run_parameters.update((flow.flow_group.default_parameters or {}))
     run_parameters.update((parameters or {}))
     required_parameters = [p["name"] for p in flow.parameters if p["required"]]


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Modifies the `create_flow_run` method to also use the set of required flow parameter defaults if they're available



## Importance
<!-- Why is this PR important? -->
Meets user expectations around setting defaults on required parameters.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
