### PR TITLE
Increase size limit

### DIFF
--- a/changes/pr273.yaml
+++ b/changes/pr273.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Increase Apollo payload size limit to 5mb - [#273](https://github.com/PrefectHQ/server/pull/273)"

--- a/services/apollo/src/index.js
+++ b/services/apollo/src/index.js
@@ -100,7 +100,7 @@ async function runServer() {
       }
     }
   })
-  server.applyMiddleware({ app, path: '/', bodyParserConfig: { limit: '1mb' } })
+  server.applyMiddleware({ app, path: '/', bodyParserConfig: { limit: '5mb' } })
   app.listen({
     host: APOLLO_API_BIND_ADDRESS,
     port: APOLLO_API_PORT,

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -15,7 +15,7 @@ core_version_cutoff = "0.6.1"
 queued_runs_returned_limit = 25
 
 # the amount of task and edges to insert in one batch
-insert_many_batch_size = 50
+insert_many_batch_size = 200
 
 # path for user configuration file
 user_config_path = "~/.prefect_server/config.toml"


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Increases the size limit for payloads in Apollo.  Goal is to allow for larger logs and an overall better UX for large payloads (5mb is still very reasonable).  



## Importance
<!-- Why is this PR important? -->
Better UX and auditing the logic between client / server side to ensure they match.  Will be following up with a Core PR to adjust the log limits accordingly.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
