### PR TITLE
add main for easy cmdline running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wheels/
 .installed.cfg
 *.egg
 pip-wheel-metadata/
+.idea
 
 # Helm packaging
 helm/prefect-server/charts

--- a/src/prefect_server/cli/__main__.py
+++ b/src/prefect_server/cli/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Add a `__main__` to make it easy to run server on cmdline


## Importance
Enables running locally via `python -m prefect_server.cli` from the `src` folder. Together with installing `prefect` using `pip install -e` this enables rapid development


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
