### PR TITLE
change RoleBinding API to rbac.authorization.k8s.io/v1

### DIFF
--- a/helm/prefect-server/templates/agent/rbac.yaml
+++ b/helm/prefect-server/templates/agent/rbac.yaml
@@ -34,7 +34,7 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "prefect-server.nameField" (merge (dict "component" "agent-role-binding") .) }}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Warning when applying the helm charts 

rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding


## Importance
It would break the helm chart for anybody who is using v1.22+
Kubernetes 1.17 support has been dropped with the release of v1.22



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
