### PR TITLE
Add edge cleanup SQL for better UX

### DIFF
--- a/services/postgres/alembic/versions/2021-08-25T121503_add_unique_constraint_on_edge_table_for_.py
+++ b/services/postgres/alembic/versions/2021-08-25T121503_add_unique_constraint_on_edge_table_for_.py
@@ -19,6 +19,26 @@ depends_on = None
 def upgrade():
     op.execute(
         """
+    --the new constraint cannot be applied if there are any duplicate edges in the edge table
+    --because edges are used only for UI Schematics, this has no effect on application logic or behavior
+    WITH duplicate_edges AS (
+	SELECT
+            MIN(id::text)::UUID AS bad_id,
+            upstream_task_id,
+            downstream_task_id
+	FROM
+            edge
+	GROUP BY
+            upstream_task_id,
+            downstream_task_id
+	HAVING
+            COUNT(*) > 1
+    ) DELETE FROM edge
+        WHERE id IN (SELECT bad_id FROM duplicate_edges);
+        """
+    )
+    op.execute(
+        """
         ALTER TABLE ONLY public.edge
         ADD CONSTRAINT edge_flow_id_task_ids_key UNIQUE (flow_id, downstream_task_id, upstream_task_id);
         """


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Adds some SQL to the previous migration which cleans up duplicate edges in the edge table; this will allow the migration to run without error, regardless of the state of a user's DB.


## Importance
<!-- Why is this PR important? -->
Better upgrade UX.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
