### PR TITLE
Add max runs per flow parameter

### DIFF
--- a/changes/issue280.yaml
+++ b/changes/issue280.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Make maximum number of scheduled runs per flow configurable - [Issue #280](https://github.com/PrefectHQ/server/issues/280)"
+
+contributor:
+  - "[Bouke Krom](https://github.com/bouke-sf)"

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -644,11 +644,9 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = 10) -> List[str]:
         return run_ids
     else:
         # attempt to pull the schedule from the flow group if possible
-        if flow.flow_group.schedule:
-            flow_schedule = flow.flow_group.schedule
         # if not possible, pull the schedule from the flow
-        else:
-            flow_schedule = flow.schedule
+        flow_schedule = flow.flow_group.schedule or flow.schedule
+
         try:
             flow_schedule = schedule_schema.load(flow_schedule)
         except Exception as exc:

--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -595,7 +595,7 @@ async def set_schedule_inactive(flow_id: str) -> bool:
 
 
 @register_api("flows.schedule_flow_runs")
-async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
+async def schedule_flow_runs(flow_id: str, max_runs: int = 10) -> List[str]:
     """
     Schedule the next `max_runs` runs for this flow. Runs will not be scheduled
     if they are earlier than latest currently-scheduled run that has auto_scheduled = True.
@@ -609,10 +609,6 @@ async def schedule_flow_runs(flow_id: str, max_runs: int = None) -> List[str]:
     Returns:
         - List[str]: the ids of the new runs
     """
-
-    if max_runs is None:
-        max_runs = 10
-
     if flow_id is None:
         raise ValueError("Invalid flow id.")
 

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -77,6 +77,9 @@ format = "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
     [services.lazarus]
     resurrection_attempt_limit = 3
 
+    [services.towel]
+    max_scheduled_runs_per_flow = 10
+
 
 # UI Colors corresponding to run states
 [state_colors]

--- a/src/prefect_server/services/towel/scheduler.py
+++ b/src/prefect_server/services/towel/scheduler.py
@@ -3,6 +3,7 @@ import asyncio
 from prefect import api, models
 from prefect.utilities.graphql import EnumValue
 
+from prefect_server import config
 from prefect_server.services.loop_service import LoopService
 
 
@@ -53,7 +54,13 @@ class Scheduler(LoopService):
 
             # concurrently schedule all runs
             all_run_ids = await asyncio.gather(
-                *[api.flows.schedule_flow_runs(flow.id) for flow in flows],
+                *[
+                    api.flows.schedule_flow_runs(
+                        flow.id,
+                        max_runs=config.services.towel.max_scheduled_runs_per_flow,
+                    )
+                    for flow in flows
+                ],
                 return_exceptions=True,
             )
             runs_scheduled += sum(

--- a/tests/services/test_scheduler.py
+++ b/tests/services/test_scheduler.py
@@ -3,6 +3,7 @@ from prefect import api
 from prefect import models as m
 
 from prefect_server.services.towel.scheduler import Scheduler
+from prefect_server import config
 
 
 @pytest.fixture(autouse=True)
@@ -28,3 +29,8 @@ async def test_scheduler_does_not_run_for_archived_flows(flow_id):
 async def test_scheduler_does_not_run_for_flows_with_inactive_schedules(flow_id):
     await api.flows.set_schedule_inactive(flow_id=flow_id)
     assert await Scheduler().run_once() == 0
+
+
+async def test_scheduler_creates_amount_configured_runs():
+    config.services.towel.max_scheduled_runs_per_flow = 100
+    assert await Scheduler().run_once() == 100


### PR DESCRIPTION
## Summary
Fixes #280 

Add a configuration parameter to the scheduler that allows to change the hardcoded maximum number of upcoming runs that will be scheduled ahead per flow.

## Importance
Changing this setting is needed when a single flow has more than 10 runs scheduled at exactly the same time (e.g. same cronstring). Currently, the scheduler will schedule 10 of them, the other ones will never be scheduled and fail silently.
The next scheduler update, these flow runs will be considered in the past and will not be scheduled anymore. Adding the configuration option will enable users to resolve the issue -- even if it is still a tricky one to detect.

## Checklist
This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
