### PR TITLE
Add loadBalancerIP option for Apollo Service

### DIFF
--- a/helm/prefect-server/templates/apollo/service.yaml
+++ b/helm/prefect-server/templates/apollo/service.yaml
@@ -14,6 +14,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- with .Values.apollo.service.publicIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   selector:
     {{- include "prefect-server.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: apollo


### PR DESCRIPTION
Adds a new option for loadBalancerIP for Apollo Service template, will allow for the use of fixed static public ips when using cloud platforms.

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Adds a new option for loadBalancerIP for Apollo Service template, will allow for the use of fixed static public ips when using cloud platforms.



## Importance
<!-- Why is this PR important? -->
Without this change, the apollo service IP will be changed after each deployment, requiring end users to keep updating the new API endpoint.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
