### PR TITLE
Release Sep 2, 2021

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sep 2, 2021 <Badge text="beta" type="success" />
+
+Released on September 2, 2021.
+
+### Enhancements
+
+- Make maximum number of scheduled runs per flow configurable - [#280](https://github.com/PrefectHQ/server/issues/280)
+- Increase Apollo payload size limit to 5mb - [#273](https://github.com/PrefectHQ/server/pull/273)
+- Separate out task and edge registration to better handle large flow registrations - [#277](https://github.com/PrefectHQ/server/pull/277)
+
+### Contributors
+
+- [Bouke Krom](https://github.com/bouke-sf)
+
 ## July 06, 2021 <Badge text="beta" type="success" />
 
 Released on July 6, 2021.

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,9 +10,14 @@ Released on September 2, 2021.
 - Increase Apollo payload size limit to 5mb - [#273](https://github.com/PrefectHQ/server/pull/273)
 - Separate out task and edge registration to better handle large flow registrations - [#277](https://github.com/PrefectHQ/server/pull/277)
 
+### Fixes
+
+- Update Helm chart RoleBinding API version - [#276](https://github.com/PrefectHQ/server/pull/276)
+
 ### Contributors
 
 - [Bouke Krom](https://github.com/bouke-sf)
+- [Guy Maliar](https://github.com/gmaliar)
 
 ## July 06, 2021 <Badge text="beta" type="success" />
 

--- a/changes/issue280.yaml
+++ b/changes/issue280.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Make maximum number of scheduled runs per flow configurable - [Issue #280](https://github.com/PrefectHQ/server/issues/280)"
-
-contributor:
-  - "[Bouke Krom](https://github.com/bouke-sf)"

--- a/changes/pr273.yaml
+++ b/changes/pr273.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Increase Apollo payload size limit to 5mb - [#273](https://github.com/PrefectHQ/server/pull/273)"

--- a/changes/pr277.yaml
+++ b/changes/pr277.yaml
@@ -1,2 +1,0 @@
-enhancement:
-  - "Separate out task and edge registration to better handle large flow registrations - [#277](https://github.com/PrefectHQ/server/pull/277)"


### PR DESCRIPTION

### Enhancements

- Make maximum number of scheduled runs per flow configurable - [#280](https://github.com/PrefectHQ/server/issues/280)
- Increase Apollo payload size limit to 5mb - [#273](https://github.com/PrefectHQ/server/pull/273)
- Separate out task and edge registration to better handle large flow registrations - [#277](https://github.com/PrefectHQ/server/pull/277)

### Contributors

- [Bouke Krom](https://github.com/bouke-sf)