### PR TITLE
Fix image pull secrets in Prefect Server helm chart

### DIFF
--- a/changes/pr289.yaml
+++ b/changes/pr289.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Fix setting `imagePullSecrets` in k8s jobs with Prefect flows in Prefect Server Helm chart - [#289](https://github.com/PrefectHQ/server/pull/289)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -24,7 +24,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: agent
     spec:
-      imagePullSecrets: {{ concat .Values.agent.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.agent.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.agent.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.agent.podSecurityContext }}
       securityContext:
@@ -48,7 +54,7 @@ spec:
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
           - name: IMAGE_PULL_SECRETS
-            value: {{ .Values.agent.job.imagePullSecrets | toJson | quote }}
+            value: {{ .Values.agent.job.imagePullSecrets | join "," | quote }}
           - name: PREFECT__CLOUD__AGENT__LABELS
             value: {{ .Values.agent.prefectLabels | toJson | quote }}
           - name: JOB_MEM_REQUEST

--- a/helm/prefect-server/templates/apollo/deployment.yaml
+++ b/helm/prefect-server/templates/apollo/deployment.yaml
@@ -23,7 +23,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: apollo
     spec:
-      imagePullSecrets: {{ concat .Values.apollo.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.apollo.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.apollo.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.apollo.podSecurityContext }}
       securityContext:

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -23,7 +23,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: graphql
     spec:
-      imagePullSecrets: {{ concat .Values.graphql.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.graphql.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.graphql.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.graphql.podSecurityContext }}
       securityContext:

--- a/helm/prefect-server/templates/hasura/deployment.yaml
+++ b/helm/prefect-server/templates/hasura/deployment.yaml
@@ -23,7 +23,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: hasura
     spec:
-      imagePullSecrets: {{ concat .Values.hasura.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.hasura.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.hasura.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.hasura.podSecurityContext }}
       securityContext:

--- a/helm/prefect-server/templates/jobs/create_tenant.yaml
+++ b/helm/prefect-server/templates/jobs/create_tenant.yaml
@@ -15,7 +15,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: create-tenant-job
     spec:
-      imagePullSecrets: {{ concat .Values.jobs.createTenant.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.jobs.createTenant.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.jobs.createTenant.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       {{- with .Values.jobs.createTenant.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/helm/prefect-server/templates/towel/deployment.yaml
+++ b/helm/prefect-server/templates/towel/deployment.yaml
@@ -23,7 +23,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: towel
     spec:
-      imagePullSecrets: {{ concat .Values.towel.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.towel.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.towel.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.towel.podSecurityContext }}
       securityContext:

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -23,7 +23,13 @@ spec:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: ui
     spec:
-      imagePullSecrets: {{ concat .Values.ui.image.pullSecrets .Values.imagePullSecrets | uniq | toJson }}
+    {{- if .Values.ui.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.ui.image.pullSecrets | nindent 8 }}
+    {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ include "prefect-server.serviceAccountName" . }}
       {{- with .Values.ui.podSecurityContext }}
       securityContext:

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -26,6 +26,7 @@ uiVersionTag: "latest"
 # resources the Helm chart's pods can get credentials from to pull
 # their images.
 imagePullSecrets: []
+  # - name: "secret_name"
 
 # annotations to merge into all object configurations
 # NOTE: These will not apply to the postgresql subchart and must be
@@ -193,6 +194,7 @@ apollo:
     tag: null
     pullPolicy: Always
     pullSecrets: []
+      # - name: "secret_for_apollo_image"
   options:
     telemetryEnabled: true
 
@@ -365,6 +367,7 @@ agent:
     # imagePullSecrets defines image pull secrets for the flow job
     # NOTE: These secrets are not merged with the global imagePullSecrets
     imagePullSecrets: []
+      # - "secret_for_flow_image"
 
 serviceAccount:
   # create specifies whether a service account should be created to be

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -134,6 +134,7 @@ hasura:
     tag: v1.3.3
     pullPolicy: IfNotPresent
     pullSecrets: []
+    # - name: "secret_name"
 
   service:
     # type defines the service type and defaults to ClusterIP
@@ -163,6 +164,7 @@ graphql:
     tag: null
     pullPolicy: Always
     pullSecrets: []
+    # - name: "secret_name"
 
   service:
     type: ClusterIP
@@ -194,7 +196,8 @@ apollo:
     tag: null
     pullPolicy: Always
     pullSecrets: []
-      # - name: "secret_for_apollo_image"
+    # - name: "secret_name"
+
   options:
     telemetryEnabled: true
 
@@ -247,6 +250,7 @@ ui:
     tag: null  # See `uiVersionTag` instead
     pullPolicy: Always
     pullSecrets: []
+    # - name: "secret_name"
 
   # apolloApiUrl defines the default gateway to the Apollo
   # GraphQL server. This location must be accessible by the
@@ -303,6 +307,7 @@ towel:
     tag: null
     pullPolicy: Always
     pullSecrets: []
+    # - name: "secret_name"
 
   labels: {}
   annotations: {}
@@ -333,6 +338,7 @@ agent:
     tag: null
     pullPolicy: Always
     pullSecrets: []
+    # - name: "secret_name"
 
   labels: {}
   annotations: {}
@@ -367,7 +373,7 @@ agent:
     # imagePullSecrets defines image pull secrets for the flow job
     # NOTE: These secrets are not merged with the global imagePullSecrets
     imagePullSecrets: []
-      # - "secret_for_flow_image"
+    # - "secret_name"
 
 serviceAccount:
   # create specifies whether a service account should be created to be
@@ -398,6 +404,7 @@ jobs:
       tag: null
       pullPolicy: Always
       pullSecrets: []
+      # - name: "secret_name"
 
     labels: {}
     annotations: {}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
In aim to connect to private container registries, you can provide k8s secrets to `imagePullSecrets` on Prefect agent deployment. You can set env var `IMAGE_PULL_SECRETS` on `prefect-agent` deployment, or if using helm chart, you can set 
```
agent:
  job:
    imagePullSecrets:
      - secret_name1
      - secret_name2
```
Instead of modifying the logic [here](https://github.com/PrefectHQ/prefect/blob/2cd13929c7701e21b8b865c36291bdee39209b95/src/prefect/agent/kubernetes/agent.py#L115), let's use Go template function `join` to convert list to a string.


## Importance
<!-- Why is this PR important? -->
Closes #286 


@TylerWanner can you please take a look?
## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [-] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
