### PR TITLE
submitted state lock

### DIFF
--- a/changes/pr291.yaml
+++ b/changes/pr291.yaml
@@ -1,0 +1,2 @@
+enhancement:
+  - "Add a submitted state lock to prevent the same flow from being run by multiple agents - [#291](https://github.com/PrefectHQ/server/pull/291)"

--- a/src/prefect_server/api/states.py
+++ b/src/prefect_server/api/states.py
@@ -18,7 +18,7 @@ logger = get_logger("api")
 
 state_schema = prefect.serialization.state.StateSchema()
 
-submitted_state_lock = TimedUniqueValueStore(duration=30.0)
+submitted_state_lock = TimedUniqueValueStore(duration=30)
 
 
 @register_api("states.set_flow_run_state")

--- a/src/prefect_server/utilities/collections.py
+++ b/src/prefect_server/utilities/collections.py
@@ -1,5 +1,6 @@
 import itertools
-from typing import Iterable
+from typing import Hashable, Iterable, Optional
+import threading
 
 
 def chunked_iterable(iterable: Iterable, size: int):
@@ -19,3 +20,60 @@ def chunked_iterable(iterable: Iterable, size: int):
         if not chunk:
             break
         yield chunk
+
+
+class TimedUniqueValueStore:
+    """
+    Stores unique values for a specific amount of time.
+
+    Args:
+        - duration (float): the number of seconds to store a value before removing it
+    """
+    def __init__(self, duration: float = 10):
+        self.values = set()
+        self.lock = threading.Lock()
+        self.duration = duration
+
+    def add_and_expire(self, value: Hashable, duration: Optional[float] = None) -> bool:
+        """
+        Add a unique value to store and kick off a timer to remove it
+
+        Args:
+            - value (Hashable): value to store, must be hashable and
+                able to be stored in a set
+            - duration (float, optional): the number of seconds to store a value
+                before removing it. Defaults to self.duration if not provided
+        Returns:
+            - bool: `True` if the value did not already exist in the store
+                and is successfully added, otherwise `False`
+        """
+        if duration is None:
+            duration = self.duration
+
+        with self.lock:
+            if value in self.values:
+                return False
+            else:
+                self.values.add(value)
+                threading.Timer(duration, self.remove, kwargs={"value": value}).start()
+                return True
+
+    def remove(self, value: Hashable):
+        """
+        Remove a value from the store
+
+        Args:
+            - value (Hashable): value to remove from store
+        """
+        with self.lock:
+            self.values.discard(value)
+
+    def exists(self, value: Hashable):
+        """
+        Check if a value exists in the store
+
+        Args:
+            - value (Hashable): value to remove from store
+        """
+        with self.lock:
+            return value in self.values

--- a/src/prefect_server/utilities/collections.py
+++ b/src/prefect_server/utilities/collections.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Hashable, Iterable, Optional
+from typing import Hashable, Iterable, Optional, Union
 import threading
 
 
@@ -27,22 +27,22 @@ class TimedUniqueValueStore:
     Stores unique values for a specific amount of time.
 
     Args:
-        - duration (float): the number of seconds to store a value before removing it
+        - duration (float, int): the number of seconds to store a value before removing it
     """
 
-    def __init__(self, duration: float = 10):
+    def __init__(self, duration: Union[float, int] = 10):
         self.values = set()
         self.lock = threading.Lock()
         self.duration = duration
 
-    def add_and_expire(self, value: Hashable, duration: Optional[float] = None) -> bool:
+    def add_and_expire(self, value: Hashable, duration: Optional[float, int] = None) -> bool:
         """
         Add a unique value to store and kick off a timer to remove it
 
         Args:
             - value (Hashable): value to store, must be hashable and
                 able to be stored in a set
-            - duration (float, optional): the number of seconds to store a value
+            - duration (float, int, optional): the number of seconds to store a value
                 before removing it. Defaults to self.duration if not provided
         Returns:
             - bool: `True` if the value did not already exist in the store

--- a/src/prefect_server/utilities/collections.py
+++ b/src/prefect_server/utilities/collections.py
@@ -29,6 +29,7 @@ class TimedUniqueValueStore:
     Args:
         - duration (float): the number of seconds to store a value before removing it
     """
+
     def __init__(self, duration: float = 10):
         self.values = set()
         self.lock = threading.Lock()

--- a/tests/api/test_states.py
+++ b/tests/api/test_states.py
@@ -166,10 +166,11 @@ class TestFlowRunStates:
         assert flow_run.heartbeat is None
 
     async def test_state_submitted_lock_on_same_flow_run_id(self, flow_run_id):
-        await api.states.set_flow_run_state(
-            flow_run_id=flow_run_id, state=Submitted()
-        )
-        with pytest.raises(ValueError, match="State update failed: this run has already been submitted."):
+        await api.states.set_flow_run_state(flow_run_id=flow_run_id, state=Submitted())
+        with pytest.raises(
+            ValueError,
+            match="State update failed: this run has already been submitted.",
+        ):
             await api.states.set_flow_run_state(
                 flow_run_id=flow_run_id, state=Submitted()
             )

--- a/tests/api/test_states.py
+++ b/tests/api/test_states.py
@@ -165,6 +165,15 @@ class TestFlowRunStates:
         flow_run = await models.FlowRun.where(id=flow_run_id).first({"heartbeat"})
         assert flow_run.heartbeat is None
 
+    async def test_state_submitted_lock_on_same_flow_run_id(self, flow_run_id):
+        await api.states.set_flow_run_state(
+            flow_run_id=flow_run_id, state=Submitted()
+        )
+        with pytest.raises(ValueError, match="State update failed: this run has already been submitted."):
+            await api.states.set_flow_run_state(
+                flow_run_id=flow_run_id, state=Submitted()
+            )
+
     @pytest.mark.parametrize("state", [Running(), Submitted()])
     async def test_running_and_submitted_state_sets_heartbeat(self, state, flow_run_id):
         """

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -1,4 +1,6 @@
-from prefect_server.utilities.collections import chunked_iterable
+import time
+
+from prefect_server.utilities.collections import chunked_iterable, TimedUniqueValueStore
 
 
 def test_chunked_iterable_of_list():
@@ -10,3 +12,22 @@ def test_chunked_iterable_of_list():
 def test_chunked_iterable_of_empty_iterable():
     chunks = [chunk for chunk in chunked_iterable([], 4)]
     assert len(chunks) == 0
+
+
+class TestTimedUniqueValueStore:
+
+    def test_add_and_expire(self):
+        store = TimedUniqueValueStore()
+        added = store.add_and_expire("value1", duration=2)
+        assert added
+        assert store.exists("value1")
+        time.sleep(3)
+        assert not store.exists("value1")
+
+    def test_add_and_expire_unique(self):
+        store = TimedUniqueValueStore()
+        added = store.add_and_expire("value1", duration=2)
+        assert added
+        assert store.exists("value1")
+        added = store.add_and_expire("value1", duration=3)
+        assert not added

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -1,6 +1,6 @@
 import time
 
-from prefect_server.utilities.collections import chunked_iterable, TimedUniqueValueStore
+from prefect_server.utilities.collections import chunked_iterable, ExpiringSet
 
 
 def test_chunked_iterable_of_list():
@@ -14,19 +14,19 @@ def test_chunked_iterable_of_empty_iterable():
     assert len(chunks) == 0
 
 
-class TestTimedUniqueValueStore:
+class TestExpiringSet:
     def test_add_and_expire(self):
-        store = TimedUniqueValueStore()
-        added = store.add_and_expire("value1", duration=2)
+        store = ExpiringSet()
+        added = store.add("value1", duration_seconds=2)
         assert added
         assert store.exists("value1")
         time.sleep(3)
         assert not store.exists("value1")
 
     def test_add_and_expire_unique(self):
-        store = TimedUniqueValueStore()
-        added = store.add_and_expire("value1", duration=2)
+        store = ExpiringSet()
+        added = store.add("value1", duration_seconds=2)
         assert added
         assert store.exists("value1")
-        added = store.add_and_expire("value1", duration=3)
+        added = store.add("value1", duration_seconds=3)
         assert not added

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -15,7 +15,6 @@ def test_chunked_iterable_of_empty_iterable():
 
 
 class TestTimedUniqueValueStore:
-
     def test_add_and_expire(self):
         store = TimedUniqueValueStore()
         added = store.add_and_expire("value1", duration=2)


### PR DESCRIPTION
## Summary
Adds an in memory in process submitted state lock. Closes #203


## Importance
Currently it is possible for multiple agents to pick up the same scheduled flow_run, this enables a buffer so that if multiple agents try to run the same flow_run only one will succeed. 


## Checklist

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
