### PR TITLE
add handling a keepalive value to apollo

### DIFF
--- a/changes/pr290.yaml
+++ b/changes/pr290.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Add ability to set keep alive timeout for graphql server - [#290](https://github.com/PrefectHQ/server/pull/290)"
+
+contributor:
+  - "[Joe McDonald](https://github.com/joe1981al)"

--- a/changes/pr293.yaml
+++ b/changes/pr293.yaml
@@ -1,0 +1,5 @@
+feature:
+  - "Add handling a keepalive value to Apollo via env variable APOLLO_KEEPALIVE_TIMEOUT - [#293](https://github.com/PrefectHQ/server/pull/293)"
+
+contributor:
+  - "[Joe M.](https://github.com/joe1981al)"

--- a/services/apollo/src/index.js
+++ b/services/apollo/src/index.js
@@ -101,11 +101,15 @@ async function runServer() {
     }
   })
   server.applyMiddleware({ app, path: '/', bodyParserConfig: { limit: '5mb' } })
-  app.listen({
+  const listener = app.listen({
     host: APOLLO_API_BIND_ADDRESS,
     port: APOLLO_API_PORT,
     family: 'IPv4'
   })
+  if ('KEEPALIVE_TIMEOUT' in process.env) {
+    listener.keepAliveTimeout = process.env.KEEPALIVE_TIMEOUT * 1000;
+    listener.headersTimeout = (process.env.KEEPALIVE_TIMEOUT + 5) * 1000;
+  }
   console.log(
     `Server ready at http://${APOLLO_API_BIND_ADDRESS}:${APOLLO_API_PORT} 🚀 (version: ${PREFECT_SERVER_VERSION})`
   )

--- a/services/apollo/src/index.js
+++ b/services/apollo/src/index.js
@@ -107,8 +107,8 @@ async function runServer() {
     family: 'IPv4'
   })
   if ('KEEPALIVE_TIMEOUT' in process.env) {
-    listener.keepAliveTimeout = process.env.KEEPALIVE_TIMEOUT * 1000;
-    listener.headersTimeout = (process.env.KEEPALIVE_TIMEOUT + 5) * 1000;
+    listener.keepAliveTimeout = process.env.KEEPALIVE_TIMEOUT * 1000
+    listener.headersTimeout = (process.env.KEEPALIVE_TIMEOUT + 5) * 1000
   }
   console.log(
     `Server ready at http://${APOLLO_API_BIND_ADDRESS}:${APOLLO_API_PORT} 🚀 (version: ${PREFECT_SERVER_VERSION})`

--- a/services/apollo/src/index.js
+++ b/services/apollo/src/index.js
@@ -106,9 +106,9 @@ async function runServer() {
     port: APOLLO_API_PORT,
     family: 'IPv4'
   })
-  if ('KEEPALIVE_TIMEOUT' in process.env) {
-    listener.keepAliveTimeout = process.env.KEEPALIVE_TIMEOUT * 1000
-    listener.headersTimeout = (process.env.KEEPALIVE_TIMEOUT + 5) * 1000
+  if ('APOLLO_KEEPALIVE_TIMEOUT' in process.env) {
+    listener.keepAliveTimeout = process.env.APOLLO_KEEPALIVE_TIMEOUT * 1000
+    listener.headersTimeout = (process.env.APOLLO_KEEPALIVE_TIMEOUT + 5) * 1000
   }
   console.log(
     `Server ready at http://${APOLLO_API_BIND_ADDRESS}:${APOLLO_API_PORT} 🚀 (version: ${PREFECT_SERVER_VERSION})`


### PR DESCRIPTION
## Summary
Adding support for setting keep alive timeout of apollo service

## Importance
Default keep alive setting causes issue with AWS ELB.  See linked blog post for details.

[Dealing with Intermittent 502's between an AWS ALB and Express Web Server](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/)

## Checklist
This PR:

- [X] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
