### PR TITLE
feat: configure apollo max body size with environment variable

### DIFF
--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -67,6 +67,9 @@ spec:
             value: server
           - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
             value: http://0.0.0.0:8080
+          {{- with .Values.agent.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         livenessProbe:
           failureThreshold: 2
           httpGet:

--- a/helm/prefect-server/templates/apollo/deployment.yaml
+++ b/helm/prefect-server/templates/apollo/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - name: GRAPHQL_SERVICE_PORT
               value: "4201"
             {{- (include "prefect-server.envConfig" .) | nindent 12 }}
+            {{- with .Values.apollo.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 4200

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - name: PREFECT_SERVER__HASURA__HOST
               value: {{ include "prefect-server.hasura-hostname" . }}
             {{- (include "prefect-server.envConfig" .) | nindent 12 }}
+            {{- with .Values.graphql.init.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.graphql.init.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -77,6 +80,9 @@ spec:
             - name: PREFECT_SERVER__HASURA__HOST
               value: {{ include "prefect-server.hasura-hostname" . }}
             {{- (include "prefect-server.envConfig" .) | nindent 12 }}
+            {{- with .Values.graphql.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 4201

--- a/helm/prefect-server/templates/hasura/deployment.yaml
+++ b/helm/prefect-server/templates/hasura/deployment.yaml
@@ -50,6 +50,9 @@ spec:
               value: "true"
             - name: HASURA_GRAPHQL_SERVER_PORT
               value: "3000"
+            {{- with .Values.hasura.env}}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/helm/prefect-server/templates/towel/deployment.yaml
+++ b/helm/prefect-server/templates/towel/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             - name: PGPASSWORD
               valueFrom:
               {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
+            {{- with .Values.towel.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.towel.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           env:
             - name: PREFECT_SERVER__APOLLO_URL
               value: {{ .Values.ui.apolloApiUrl }}
+            {{- with .Values.ui.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -147,6 +147,7 @@ hasura:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -173,6 +174,7 @@ graphql:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -182,6 +184,7 @@ graphql:
   init:
     # init.resources configures resources for the initContainer
     # which upgrades the database
+    env: {}
     resources: {}
 
 # apollo configures the Prefect apollo deployment and service
@@ -232,6 +235,7 @@ apollo:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -288,6 +292,7 @@ ui:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -308,6 +313,7 @@ towel:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -338,6 +344,7 @@ agent:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
+  env: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/services/apollo/src/index.js
+++ b/services/apollo/src/index.js
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid'
 const express = require('express')
 const APOLLO_API_PORT = process.env.APOLLO_API_PORT || '4200'
 const APOLLO_API_BIND_ADDRESS = process.env.APOLLO_API_BIND_ADDRESS || '0.0.0.0'
+const APOLLO_API_BODY_LIMIT = process.env.APOLLO_API_BODY_LIMIT || '5mb'
 
 const PREFECT_API_HEALTH_URL =
   process.env.PREFECT_API_HEALTH_URL || 'http://localhost:4201/health'
@@ -100,7 +101,11 @@ async function runServer() {
       }
     }
   })
-  server.applyMiddleware({ app, path: '/', bodyParserConfig: { limit: '5mb' } })
+  server.applyMiddleware({
+    app,
+    path: '/',
+    bodyParserConfig: { limit: APOLLO_API_BODY_LIMIT }
+  })
   app.listen({
     host: APOLLO_API_BIND_ADDRESS,
     port: APOLLO_API_PORT,


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

This PR introduces two things:
1. It allows to configure the body size of apollo with an environment variable
2. For helm users, it allows to configure environment variables per service through values



## Importance
<!-- Why is this PR important? -->

Currently, I can't create a markdown artifact as I'm running into: `413 Payload Too Large`

```
prefect-job-231d65d2-2p6h9 flow [2021-09-24 07:35:34+0000] ERROR - prefect.CloudTaskRunner | Task 'submit_artifact_task': Exception encountered during task execution!
prefect-job-231d65d2-2p6h9 flow Traceback (most recent call last):
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/engine/task_runner.py", line 861, in get_task_run_state
prefect-job-231d65d2-2p6h9 flow     value = prefect.utilities.executors.run_task_with_timeout(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/utilities/executors.py", line 328, in run_task_with_timeout
prefect-job-231d65d2-2p6h9 flow     return task.run(*args, **kwargs)  # type: ignore
prefect-job-231d65d2-2p6h9 flow   File "/home/runner/work/prefect/prefect/src/flows/monitoring/schema_changes/flow.py", line 206, in submit_artifact_task
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/artifacts.py", line 85, in create_markdown
prefect-job-231d65d2-2p6h9 flow     return _create_task_run_artifact("markdown", {"markdown": markdown})
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/artifacts.py", line 28, in _create_task_run_artifact
prefect-job-231d65d2-2p6h9 flow     return client.create_task_run_artifact(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 2078, in create_task_run_artifact
prefect-job-231d65d2-2p6h9 flow     result = self.graphql(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 543, in graphql
prefect-job-231d65d2-2p6h9 flow     result = self.post(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 446, in post
prefect-job-231d65d2-2p6h9 flow     response = self._request(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 710, in _request
prefect-job-231d65d2-2p6h9 flow     response = self._send_request(
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/prefect/client/client.py", line 620, in _send_request
prefect-job-231d65d2-2p6h9 flow     response.raise_for_status()
prefect-job-231d65d2-2p6h9 flow   File "/usr/local/lib/python3.8/site-packages/requests/models.py", line 943, in raise_for_status
prefect-job-231d65d2-2p6h9 flow     raise HTTPError(http_error_msg, response=self)
prefect-job-231d65d2-2p6h9 flow requests.exceptions.HTTPError: 413 Client Error: Payload Too Large for url: http://prefect-apollo.prefect:4200/graphql/graphql
```

The limit was that apollo is capped at 5mb.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
