### PR TITLE
Refuse to set schedules active for flows without any schedule

### DIFF
--- a/src/prefect_server/api/flows.py
+++ b/src/prefect_server/api/flows.py
@@ -549,6 +549,11 @@ async def set_schedule_active(flow_id: str) -> bool:
         if not all([required_names <= c for c in clock_params]):
             raise ValueError("Can not schedule a flow that has required parameters.")
 
+    # if there is no referenceable schedule for this Flow, do not change the schedule
+    # to active to avoid confusion
+    if flow.schedule is None and getattr(flow.flow_group, "schedule", None) is None:
+        return False
+
     result = await models.Flow.where(id=flow_id).update(
         set={"is_schedule_active": True}
     )


### PR DESCRIPTION
Resolves https://github.com/PrefectHQ/cloud/issues/3753

Prefect Core now always passes `set_schedule_active=False` to  `create_flow` then sets the schedule active using `set_schedule_active` after registration. This is necessary to prevent flows from running while batched registration is occurring. `create_flow` had handling to check for flows without schedules and ignore the schedule toggle, but `set_schedule_active` does not. This means that flows without schedules are now set to active by default. This has no effect since there is no schedule to run, but is concerning to users and confusing in the UI. This PR updates `flows.set_schedule_active` to refuse to set the schedule to active for flows without a schedule attached either to the flow or flow group.

Introduced in 0.15.5 in https://github.com/PrefectHQ/prefect/pull/4930

Until this fix is live, users can avoid seeing "active" schedules for flows without schedules by setting `set_schedule_active=False` when they register their flows.