### PR TITLE
Fix connection url for `createTenant` helm job

### DIFF
--- a/helm/prefect-server/templates/jobs/create_tenant.yaml
+++ b/helm/prefect-server/templates/jobs/create_tenant.yaml
@@ -39,7 +39,7 @@ spec:
             - "-c"
             - "prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }} || [[ $(prefect server create-tenant --name {{ .Values.jobs.createTenant.tenant.name }} --slug {{ .Values.jobs.createTenant.tenant.slug }}  2>&1) =~ 'Uniqueness violation' ]]"
           env:
-            - name: PREFECT__CLOUD__GRAPHQL
+            - name: PREFECT__CLOUD__API
               value: {{ include "prefect-server.apollo-api-url" . }}
             - name: PREFECT__BACKEND
               value: server


### PR DESCRIPTION
The Prefect Core client behavior has changed and it pulls the API url from a different config key now which breaks the `createTenant` job in the helm chart. 

See also https://github.com/PrefectHQ/prefect/pull/4914