### PR TITLE
Fix Agent Helm chart template env block

### DIFF
--- a/changes/pr312.yaml
+++ b/changes/pr312.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Fix agent env block construction in Helm chart - [#312](https://github.com/PrefectHQ/server/pull/312)"
+
+contributor:
+  - "[Rob Williams](https://github.com/rwilliams-exs)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
             value: http://0.0.0.0:8080
           {{- with .Values.agent.env }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
         livenessProbe:
           failureThreshold: 2

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -352,7 +352,7 @@ agent:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary
<!-- A sentence summarizing the PR -->

The current format of the Helm templating uses indentation one step too deep, resulting in formatting errors when used. This change corrects that indentation, and changes the default value in the `values.yaml` file to avoid incorrect warning messages.



## Importance
<!-- Why is this PR important? -->

Allows for actually providing custom environment variables to the agent


## More information

`values.yaml` file contents:

```
agent:
  enabled: true
  env:
    - name: foo
      value: bar
```
### Pre-change

`helm template helm/prefect-server --values values.yaml` excerpt:

```
...
          - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
            value: http://0.0.0.0:8080
            - name: foo
              value: bar
...
```

Accompanying error message:

`Error: YAML parse error on prefect-server/templates/agent/deployment.yaml: error converting YAML to JSON: yaml: line 61: did not find expected key`

### Post change

`helm template helm/prefect-server --values values.yaml` excerpt:

```
...
          - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
            value: http://0.0.0.0:8080
          - name: foo
            value: bar
...
```

Error message resolved