### PR TITLE
Don't pass pgpassword to towel.

### DIFF
--- a/changes/pr316.yaml
+++ b/changes/pr316.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Remove PGPASSWORD from towel helm chart. - [#316](https://github.com/PrefectHQ/server/pull/316)"

--- a/helm/prefect-server/templates/towel/deployment.yaml
+++ b/helm/prefect-server/templates/towel/deployment.yaml
@@ -48,10 +48,7 @@ spec:
             - src/prefect_server/services/towel/__main__.py
           env:
             - name: PREFECT_SERVER__HASURA__HOST
-              value: {{ include "prefect-server.hasura-hostname" . }}
-            - name: PGPASSWORD
-              valueFrom:
-              {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
+              value: {{ include "prefect-server.hasura-hostname" . }}            
             {{- with .Values.towel.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Closes https://github.com/PrefectHQ/server/issues/315

Without the rest of the PG connection string (`{{ include "prefect-server.postgres-connstr" . }}`) the password seems useless.

Compare it for example to hasura that receives both the connection string and the password
https://github.com/PrefectHQ/server/blob/e8845108459c6889b1e359b260681a91533173f8/helm/prefect-server/templates/hasura/deployment.yaml#L50-L54

## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] successfully rendering the template with `helm template helm/prefect-server` 
- [ ] ~adds new tests (if appropriate)~
- [ ] ~adds a change file in the `changes/` directory (if appropriate)~
