### PR TITLE
Prevent create_flow_run from succeeding with bad params

### DIFF
--- a/changes/pr317.yaml
+++ b/changes/pr317.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Prevent create_flow_run to succeed with bad parameters- [#314](https://github.com/PrefectHQ/server/pull/317)"
+
+contributor:
+  - "[Pawel Janowski](https://github.com/pjanowski)"

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -164,18 +164,19 @@ async def create_flow_run(
         param["name"]: param["default"] for param in flow.parameters if param["default"]
     }
 
-    # check for supplied params not in run params
-    if parameters:
-        unknown_parameters = set(parameters.keys()).difference(
-            set(run_parameters.keys())
-        )
-        if unknown_parameters:
-            raise ValueError(
-                f"Unknown parameters supplied to Flow {flow.id}'s. Unknown parameters: {unknown_parameters}."
-            )
-
     run_parameters.update(flow.flow_group.default_parameters or {})
     run_parameters.update((parameters or {}))
+
+    # check for supplied params not in the flow's params
+    unknown_parameters = set(run_parameters.keys()).difference(
+        set(flow.parameters.keys())
+    )
+    if unknown_parameters:
+        raise ValueError(
+            f"Unknown parameters supplied to Flow {flow.id}'s. Unknown parameters: {unknown_parameters}."
+        )
+
+    # check for supplied params missing required params
     required_parameters = [p["name"] for p in flow.parameters if p["required"]]
     missing = set(required_parameters).difference(run_parameters)
     if missing:

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -168,9 +168,8 @@ async def create_flow_run(
     run_parameters.update((parameters or {}))
 
     # check for supplied params not in the flow's params
-    unknown_parameters = set(run_parameters.keys()).difference(
-        set(flow.parameters.keys())
-    )
+    flow_param_names = [param["name"] for param in flow.parameters]
+    unknown_parameters = set(run_parameters.keys()).difference(flow_param_names)
     if unknown_parameters:
         raise ValueError(
             f"Unknown parameters supplied to Flow {flow.id}'s. Unknown parameters: {unknown_parameters}."

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -165,11 +165,12 @@ async def create_flow_run(
     }
 
     # check for supplied params not in run params
-    unknown_parameters = set(parameters.keys()).difference(set(run_parameters.keys()))
-    if unknown_parameters:
-        raise ValueError(
-            f"Unknown parameters supplied to Flow {flow.id}'s. Unknown_parameters: {unknown_parameters}."
-        )
+    if parameters:
+        unknown_parameters = set(parameters.keys()).difference(set(run_parameters.keys()))
+        if unknown_parameters:
+            raise ValueError(
+                f"Unknown parameters supplied to Flow {flow.id}'s. Unknown parameters: {unknown_parameters}."
+            )
 
     run_parameters.update(flow.flow_group.default_parameters or {})
     run_parameters.update((parameters or {}))

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -166,7 +166,9 @@ async def create_flow_run(
 
     # check for supplied params not in run params
     if parameters:
-        unknown_parameters = set(parameters.keys()).difference(set(run_parameters.keys()))
+        unknown_parameters = set(parameters.keys()).difference(
+            set(run_parameters.keys())
+        )
         if unknown_parameters:
             raise ValueError(
                 f"Unknown parameters supplied to Flow {flow.id}'s. Unknown parameters: {unknown_parameters}."

--- a/src/prefect_server/api/runs.py
+++ b/src/prefect_server/api/runs.py
@@ -163,6 +163,14 @@ async def create_flow_run(
     run_parameters = {
         param["name"]: param["default"] for param in flow.parameters if param["default"]
     }
+
+    # check for supplied params not in run params
+    unknown_parameters = set(parameters.keys()).difference(set(run_parameters.keys()))
+    if unknown_parameters:
+        raise ValueError(
+            f"Unknown parameters supplied to Flow {flow.id}'s. Unknown_parameters: {unknown_parameters}."
+        )
+
     run_parameters.update(flow.flow_group.default_parameters or {})
     run_parameters.update((parameters or {}))
     required_parameters = [p["name"] for p in flow.parameters if p["required"]]

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -273,6 +273,19 @@ class TestCreateRun:
         flow_run = await models.FlowRun.where(id=flow_run_id).first({"parameters"})
         assert flow_run.parameters == dict(x=1)
 
+    async def test_create_run_with_bad_parameters_raises_error(self, project_id):
+        flow_id = await api.flows.create_flow(
+            project_id=project_id,
+            serialized_flow=prefect.Flow(
+                name="test", tasks=[prefect.Parameter("x"), prefect.Parameter("y")]
+            ).serialize(),
+        )
+
+        with pytest.raises(ValueError) as exc:
+            await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=1,z=2))
+
+        assert "Unknown parameters" in str(exc.value)
+
     async def test_create_run_uses_default_flow_group_parameters(self, project_id):
         flow_id = await api.flows.create_flow(
             project_id=project_id,

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -260,7 +260,7 @@ class TestCreateRun:
             ).serialize(),
         )
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError) as exc: 
             await api.runs.create_flow_run(flow_id=flow_id)
 
         assert "Required parameters were not supplied" in str(exc.value)
@@ -282,7 +282,7 @@ class TestCreateRun:
         )
 
         with pytest.raises(ValueError) as exc:
-            await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=1,z=2))
+            await api.runs.create_flow_run(flow_id=flow_id, parameters=dict(x=1, z=2))
 
         assert "Unknown parameters" in str(exc.value)
 

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -260,7 +260,7 @@ class TestCreateRun:
             ).serialize(),
         )
 
-        with pytest.raises(ValueError) as exc: 
+        with pytest.raises(ValueError) as exc:
             await api.runs.create_flow_run(flow_id=flow_id)
 
         assert "Required parameters were not supplied" in str(exc.value)


### PR DESCRIPTION
## Summary
Fix `create_flow_run` to disallow incorrect flow parameters.




## Importance
This PR fixes the `runs.create_flow_run` mutation to disallow passing of bad parameters. Currently, if a user invokes `create_flow_run` and passes parameters that do not exist in the flow for which a run is being created, the flow run will be created successfully with the bad parameters. These will be noop's and the flow will run with it's default parameter values. (eg. if a flow run will has parameter 'pizza' with default value 'pepperoni' and the user tries to create a flow run with parameter 'piza' and value 'sausage', the flow run will successfully be created with parameters `{'pizza':'pepperoni', 'piza':'sausage'}` ). This leads to unintended and hard to debug behavior. The fix checks to make sure that all the parameters passed by the caller are valid parameters of the flow being invoked. 



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
