### PR TITLE
feat: configurable artifact max payload size

### DIFF
--- a/changes/pr320.yaml
+++ b/changes/pr320.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Configure the maximum artifact payload - [#320](https://github.com/PrefectHQ/server/pull/320)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/src/prefect_server/config.toml
+++ b/src/prefect_server/config.toml
@@ -20,6 +20,9 @@ insert_many_batch_size = 200
 # path for user configuration file
 user_config_path = "~/.prefect_server/config.toml"
 
+# maximum amount of bytes artifact accepts, defaults to 1 mb.
+artifacts_max_payload_bytes = 1000000
+
 [api]
 url = 'http://localhost:4200'
 

--- a/src/prefect_server/graphql/artifacts.py
+++ b/src/prefect_server/graphql/artifacts.py
@@ -6,6 +6,7 @@ from typing import Any
 from graphql import GraphQLResolveInfo
 
 from prefect import api
+from prefect_server import config
 from prefect_server.utilities.graphql import mutation
 
 
@@ -17,8 +18,10 @@ async def resolve_create_task_run_artifact(
     data = input.get("data")
 
     data_size = sys.getsizeof(json.dumps(data))
-    if data_size > 1000000:  # 1 mb max
-        raise ValueError("Artifact data payload exceedes 1Mb limit.")
+    if data_size > config.artifacts_max_payload_bytes:
+        raise ValueError(
+            f"Artifact data payload exceeds {config.artifacts_max_payload_bytes} bytes limit."
+        )
 
     task_run_artifact_id = await api.artifacts.create_task_run_artifact(
         task_run_id=input.get("task_run_id"),


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Makes the payload size configurable for artifact creation.


## Importance
<!-- Why is this PR important? -->

Allows users to create larger artifacts than default 1 Mb. 


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)


Fixes #319 