### PR TITLE
Clarify how to set password for the Postgres database in the Server Helm chart documentation

### DIFF
--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -197,6 +197,16 @@ We strongly recommend that you do not deploy a production database using this ch
 The provided database will **not** persist your data by default.
 When connecting to an external database, PostgreSQL 11+ is recommended.
 
+In order to use an external database with this Helm chart, you need to create a Kubernetes secret that will contain the database password. This secret must be a key-value pair containing the key `postgresql-password`. You need to create this secret yourself before referencing the secret name under `existingSecret`. The name of the Kubernetes secret is arbitrary, e.g.: 
+
+    kubectl create secret generic prefect-postgresql-pwd --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
+
+Here is how you could use this secret in values.yaml:
+
+    existingSecret: prefect-postgresql-pwd
+
+Note that the argument `postgresqlPassword` will be ignored in this case. This argument is only relevant when using the Postgres database included in the chart. For an external database, you must create and use `existingSecret` instead of `postgresqlPassword`.
+
 An external database will require some minimal setup for Hasura.
 The following needs to be run or the user should have permissions to execute it and Hasura will run it on startup:
 

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -197,13 +197,13 @@ We strongly recommend that you do not deploy a production database using this ch
 The provided database will **not** persist your data by default.
 When connecting to an external database, PostgreSQL 11+ is recommended.
 
-In order to use an external database with this Helm chart, you need to create a Kubernetes secret that will contain the database password. This secret must be a key-value pair containing the key `postgresql-password`. You need to create this secret yourself before referencing the secret name under `existingSecret`. The name of the Kubernetes secret is arbitrary, e.g.: 
+In order to use an external database with this Helm chart, you need to create a Kubernetes secret that will contain the database password. This secret must be a key-value pair containing the key `postgresql-password`. You need to create this secret yourself, then reference the secret name using `existingSecret`. The name of the Kubernetes secret is arbitrary, e.g.: 
 
-    kubectl create secret generic prefect-postgresql-pwd --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
+```shell
+kubectl create secret generic prefect-postgresql-pwd --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
+```
 
-Here is how you could use this secret in values.yaml:
-
-    existingSecret: prefect-postgresql-pwd
+Then, add the flag `--set postgresql.existingSecret=prefect-postgresql-pwd` to the helm install command to use this secret to connect to your database.
 
 Note that the argument `postgresqlPassword` will be ignored in this case. This argument is only relevant when using the Postgres database included in the chart. For an external database, you must create and use `existingSecret` instead of `postgresqlPassword`.
 

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -54,7 +54,7 @@ postgresql:
   # enabled, the secret will be generated. If using an external
   # postgres service, this value should be set to the name of 
   # an existing Kubernetes secret. This secret must contain 
-  # a key-value pair where the key is postgresql-password 
+  # a key-value pair where the key is `postgresql-password `
   # and the value is your password. For more information, 
   # see the "Database" section of the README.
   existingSecret: null

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -55,6 +55,8 @@ postgresql:
   # postgres service, this value should be explicitly set to
   # the name of a Kubernetes secret. This secret must be a
   # key-value pair containing the key `postgresql-password`.
+  # Note that you need to create this secret yourself before
+  # referencing the secret name under `existingSecret`.
   # The name of the Kubernetes secret is arbitrary.  e.g.:
   # kubectl create secret generic prefect-postgresql-pwd
   # --from-literal='postgresql-password=YOUR_POSTGRES_PWD'

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -52,21 +52,20 @@ postgresql:
   # existingSecret configures which secret should be referenced
   # for access to the database. If null and `useSubChart` is
   # enabled, the secret will be generated. If using an external
-  # postgres service, this value should be explicitly set to
-  # the name of a Kubernetes secret. This secret must be a
-  # key-value pair containing the key `postgresql-password`.
-  # Note that you need to create this secret yourself before
-  # referencing the secret name under `existingSecret`.
-  # The name of the Kubernetes secret is arbitrary.  e.g.:
-  # kubectl create secret generic prefect-postgresql-pwd
-  # --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
-  # Helm chart value: existingSecret: prefect-postgresql-pwd
+  # postgres service, this value should be set to the name of 
+  # an existing Kubernetes secret. This secret must contain 
+  # a key-value pair where the key is postgresql-password 
+  # and the value is your password. For more information, 
+  # see the "Database" section of the README.
   existingSecret: null
 
   # postgresqlPassword sets the password to be used if
   # `existingSecret` is not set. This is the password for
   # `postgresqlUsername` and will be set within the secret at
-  # the key `postgresql-password`
+  # the key `postgresql-password`. This argument is only relevant 
+  # when using the Postgres database included in the chart. 
+  # For an external postgres connection, you must create 
+  # and use `existingSecret` instead of `postgresqlPassword`.
   # postgresqlPassword: use-a-strong-password
 
   # servicePort configures the port that the database should be

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -52,8 +52,13 @@ postgresql:
   # existingSecret configures which secret should be referenced
   # for access to the database. If null and `useSubChart` is
   # enabled, the secret will be generated. If using an external
-  # postgres service, this value should be set to the name of a
-  # Kubernetes secret containing the key `postgresql-password`
+  # postgres service, this value should be explicitly set to
+  # the name of a Kubernetes secret. This secret must be a
+  # key-value pair containing the key `postgresql-password`.
+  # The name of the Kubernetes secret is arbitrary.  e.g.:
+  # kubectl create secret generic prefect-postgresql-pwd
+  # --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
+  # Helm chart value: existingSecret: prefect-postgresql-pwd
   existingSecret: null
 
   # postgresqlPassword sets the password to be used if


### PR DESCRIPTION
Clarifying how the Kubernetes secret should be set on the Helm chart values when using an existing Postgres database rather than the one included with a sub-chart. 
