### PR TITLE
[Feature] Allows custom job templates on helm chart

### DIFF
--- a/changes/pr322.yaml
+++ b/changes/pr322.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+feature:
+  - "Allows custom job templates on helm chart - [#322](https://github.com/PrefectHQ/server/pull/322)"
+
+contributor:
+  - "[Gabriel Gazola Milan](https://github.com/gabriel-milan)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -47,8 +47,8 @@ spec:
         command:
           - bash
           - "-c"
-          {{- if .Values.agent.jobTemplate }}
-          - "prefect agent kubernetes start --job-template {{ .Values.agent.jobTemplate }}"
+          {{- if .Values.agent.jobTemplateFilePath }}
+          - "prefect agent kubernetes start --job-template {{ .Values.agent.jobTemplateFilePath }}"
           {{- else }}
           - "prefect agent kubernetes start"
           {{- end }}

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -47,7 +47,11 @@ spec:
         command:
           - bash
           - "-c"
+          {{- if .Values.agent.jobTemplate }}
+          - "prefect agent kubernetes start --job-template {{ .Values.agent.jobTemplate }}"
+          {{- else }}
           - "prefect agent kubernetes start"
+          {{- end }}
         env:
           - name: PREFECT__CLOUD__API
             value: {{ include "prefect-server.apollo-api-url" . }}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -338,10 +338,10 @@ agent:
   # be associated with the agent
   prefectLabels: []
 
-  # jobTemplate defines which template to use for the agent's jobs. Defaults
+  # jobTemplateFilePath defines which template to use for the agent's jobs. Defaults
   # to an empty string, which will use the default template.
   # reference: https://docs.prefect.io/orchestration/agents/kubernetes.html#custom-job-template
-  jobTemplate: ""
+  jobTemplateFilePath: ""
 
   # image configures the container image for the agent deployment
   image:

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -338,6 +338,11 @@ agent:
   # be associated with the agent
   prefectLabels: []
 
+  # jobTemplate defines which template to use for the agent's jobs. Defaults
+  # to an empty string, which will use the default template.
+  # reference: https://docs.prefect.io/orchestration/agents/kubernetes.html#custom-job-template
+  jobTemplate: ""
+
   # image configures the container image for the agent deployment
   image:
     name: prefecthq/prefect


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
This allows setting a custom job template directly on the `values.yaml` file.




## Importance
In our use case, the only thing we needed to do was to set environment variables for all our jobs using `envFrom`. With this change (tested and working for us) it allows us to change the job template directly on the `values.yaml` file, making it much easier to manage.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (not applicable, I guess. please correct me if I'm wrong)
- [x] adds a change file in the `changes/` directory (wip)
