### PR TITLE
Add podAnnotations to helm chart.

### DIFF
--- a/changes/pr327.yaml
+++ b/changes/pr327.yaml
@@ -1,0 +1,23 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+enhancement:
+  - "Add podAnnotations to helm chart - [#327](https://github.com/PrefectHQ/server/pull/327)"
+
+contributor:
+  - "[Lukáš Novotný](https://github.com/novotl)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: agent
+      {{- with .Values.agent.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.agent.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/templates/apollo/deployment.yaml
+++ b/helm/prefect-server/templates/apollo/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: apollo
+      {{- with .Values.apollo.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.apollo.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: graphql
+      {{- with .Values.graphql.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.graphql.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/templates/hasura/deployment.yaml
+++ b/helm/prefect-server/templates/hasura/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: hasura
+      {{- with .Values.hasura.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.hasura.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/templates/towel/deployment.yaml
+++ b/helm/prefect-server/templates/towel/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: towel
+      {{- with .Values.towel.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.towel.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/templates/ui/deployment.yaml
+++ b/helm/prefect-server/templates/ui/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "prefect-server.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: ui
+      {{- with .Values.ui.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.ui.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -150,6 +150,7 @@ hasura:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}
@@ -176,6 +177,7 @@ graphql:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}
@@ -239,6 +241,7 @@ apollo:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}
@@ -297,6 +300,7 @@ ui:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}
@@ -319,6 +323,7 @@ towel:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}
@@ -354,6 +359,7 @@ agent:
 
   labels: {}
   annotations: {}
+  podAnnotations: {}
   replicas: 1
   strategy: {}
   podSecurityContext: {}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Closes #318 

Adding `podAnnotations` field for each deployment to allow attaching arbitrary metadata to pods.

## Importance
<!-- Why is this PR important? -->

Useful for e.g. monitoring tools. See the issue #318 description for more info



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
  - [x] running `helm template helm/prefect-server -f helm/prefect-server/values.yaml` locally successfully renders templates 
- [x] adds a change file in the `changes/` directory (if appropriate)
