### PR TITLE
fix: Change default helm env values from map to list

### DIFF
--- a/changes/issue331.yaml
+++ b/changes/issue331.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "Fix default env values for helm chart - [#331](https://github.com/PrefectHQ/server/issues/331)"
+
+contributor:
+  - "[Oreon Lothamer](https://github.com/oreonl)"

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -155,7 +155,7 @@ hasura:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -182,7 +182,7 @@ graphql:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -191,7 +191,7 @@ graphql:
   init:
     # init.resources configures resources for the initContainer
     # which upgrades the database
-    env: {}
+    env: []
     resources: {}
 
 # apollo configures the Prefect apollo deployment and service
@@ -246,7 +246,7 @@ apollo:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -305,7 +305,7 @@ ui:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -328,7 +328,7 @@ towel:
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
-  env: {}
+  env: []
   resources: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
The default values for the different env variables in the helm chart values.yaml file are set to an empty map, but the templates are setup so that you need to pass in a list. This causes a conflict when you try and set these values. This PR updates the default env values to an empty list.

See issue https://github.com/PrefectHQ/server/issues/331


## Importance
<!-- Why is this PR important? -->
If you attempt to pass in values for the env you get an error:
```
Error: failed parsing --set data: unable to parse key: interface conversion: interface {} is map[string]interface {}, not []interface {}
```



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
