### PR TITLE
Bump hasura image version to 2.1.1 to fix M1 support

### DIFF
--- a/docker/infrastructure/docker-compose.yml
+++ b/docker/infrastructure/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "-c"
       - "max_connections=150"
   hasura:
-    image: "hasura/graphql-engine:v2.0.9"
+    image: "hasura/graphql-engine:v2.1.1"
     ports:
       - "3000:3000"
     command: "graphql-engine serve"


### PR DESCRIPTION
Proper Apple Silicon support was added to hasura/graphql engine in v2.1.0 which should mean the prefect server can start up on M1 Macs without them needing 8GB of RAM!

I've tested this locally and everything seems to work great, with ~4 GB of RAM allocated to the Docker VM.

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Proper Apple Silicon support was added to `hasura/graphql` engine in [v2.1.0](https://github.com/hasura/graphql-engine/releases/tag/v2.1.0). This brings v2.1.1 into the Server.

There's a [matching PR](https://github.com/PrefectHQ/prefect/pull/5335) in the `prefect` repo.


## Importance
<!-- Why is this PR important? -->

This should mean the prefect server can start up on M1 Macs without them needing [8GB of RAM](https://github.com/hasura/graphql-engine/issues/6337#issuecomment-969300069)!




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~~adds new tests (if appropriate)~~
- [ ] adds a change file in the `changes/` directory (if appropriate)
