### PR TITLE
Reduce flow run reschedule limit on Lazarus

### DIFF
--- a/changes/pr350.yaml
+++ b/changes/pr350.yaml
@@ -1,0 +1,21 @@
+# An example changelog entry
+#
+# 1. Choose one (or more if a PR encompasses multiple changes) of the following headers:
+#   - feature
+#   - enhancement
+#   - fix
+#   - deprecation
+#   - breaking (for breaking changes)
+#   - migration (for database migrations)
+#
+# 2. Fill in one (or more) bullet points under the heading, describing the change.
+#    Markdown syntax may be used.
+#
+# 3. If you would like to be credited as helping with this release, add a
+#    contributor section with your name and github username.
+#
+# Here's an example of a PR that adds an enhancement
+
+fix:
+  - "Reduce maximum flow runs rescheduled by Lazarus at once - [#350](https://github.com/PrefectHQ/server/pull/350)"
+

--- a/src/prefect_server/services/towel/lazarus.py
+++ b/src/prefect_server/services/towel/lazarus.py
@@ -86,7 +86,7 @@ class Lazarus(LoopService):
         flow_runs = await models.FlowRun.where(where_clause).get(
             selection_set={"id", "version", "tenant_id", "times_resurrected"},
             order_by={"updated": EnumValue("asc")},
-            limit=5000,
+            limit=500,
         )
 
         if flow_runs:


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->
Reduces the maximum amount of flow runs Lazarus will query for at once.

With sufficient stress placed on the database, `Lazarus.reschedule_flow_runs` will time out and raise an exception, effectively breaking Lazarus. Reducing the limit in this PR reduces the chance the query will time out.



## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- ~[ ] adds new tests (if appropriate)~
- [x] adds a change file in the `changes/` directory (if appropriate)
