### PR TITLE
Include the chart name in component names

### DIFF
--- a/helm/prefect-server/templates/_helpers.tpl
+++ b/helm/prefect-server/templates/_helpers.tpl
@@ -37,8 +37,9 @@
     Name fields are limited to 63 characters by the DNS naming spec
 */}}
 {{- define "prefect-server.nameField" -}}
-{{- $name := print (.namePrefix | default "") ( .component ) (.nameSuffix | default "") -}}
-{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- $componentName := print (.namePrefix | default "") ( .component ) (.nameSuffix | default "") -}}
+{{- $chartName := include "prefect-server.name" . -}}
+{{ printf "%s-%s-%s" .Release.Name $chartName $componentName | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 


### PR DESCRIPTION
Resolves issues when the Prefect Server chart is used as a subchart where names could collide with other charts. Allows 'nameOverride' to affect names globally