### PR TITLE
Use https to retrieve latest tags for Helm chart pins

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,14 +17,17 @@ jobs:
       - name: Get the version tags
         id: get_version
         run: |
+          # Enable pipefail so git command failures do not result in null versions downstream
+          set -x
+
           echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
           echo ::set-output name=CORE_VERSION::$(\
             git ls-remote --tags --refs --sort="v:refname" \
-            git://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
+            https://github.com/PrefectHQ/prefect.git | tail -n1 | sed 's/.*\///' \
           )
           echo ::set-output name=UI_VERSION::$(\
             git ls-remote --tags --refs --sort="v:refname" \
-            git://github.com/PrefectHQ/ui.git | tail -n1 | sed 's/.*\///' \
+            https://github.com/PrefectHQ/ui.git | tail -n1 | sed 's/.*\///' \
           )
 
       - name: Configure Git


### PR DESCRIPTION
Using `git://` without authentication is [no longer supported](https://github.blog/2021-09-01-improving-git-protocol-security-github/) and causes the following failure resulting in invalid version tags in the published chart.

```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Closes https://github.com/PrefectHQ/server/issues/361 and #357 
