### PR TITLE
Helm: Remove duplicate envvar in graphql deployment

### DIFF
--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -56,8 +56,6 @@ spec:
             - name: PGPASSWORD
               valueFrom:
                 {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
-            - name: PREFECT_SERVER__HASURA__HOST
-              value: {{ include "prefect-server.hasura-hostname" . }}
             {{- (include "prefect-server.envConfig" .) | nindent 12 }}
             {{- with .Values.graphql.init.env }}
               {{- toYaml . | nindent 12 }}
@@ -85,9 +83,7 @@ spec:
               value: {{ include "prefect-server.postgres-connstr" . }}
             - name: PGPASSWORD
               valueFrom:
-                {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}            
-            - name: PREFECT_SERVER__HASURA__HOST
-              value: {{ include "prefect-server.hasura-hostname" . }}
+                {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
             {{- (include "prefect-server.envConfig" .) | nindent 12 }}
             {{- with .Values.graphql.env }}
               {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This envvar is already defined here: https://github.com/PrefectHQ/server/blob/master/helm/prefect-server/templates/_helpers.tpl#L199-L200. So, it ends up twice in the env map. This fails on a server-side apply