### PR TITLE
Bumping hasura image to 2.1.1 - helm

### DIFF
--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -144,7 +144,7 @@ hasura:
   # Prefect
   image:
     name: hasura/graphql-engine
-    tag: v2.0.9
+    tag: v2.1.1
     pullPolicy: IfNotPresent
     pullSecrets: []
     # - name: "secret_name"


### PR DESCRIPTION
Bumping hasura image to 2.1.1 to match docker compose and include fix for M1 mac

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Bumping hasura image to 2.1.1 to match docker compose and include fix for M1 mac

This probably should have been included in [PR 337](https://github.com/PrefectHQ/server/pull/337)


## Importance
<!-- Why is this PR important? -->

Fixes issues with M1 mac


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
