### PR TITLE
Add resources for the Create Tenant job in Prefect Server Helm chart

### DIFF
--- a/changes/pr371.md
+++ b/changes/pr371.md
@@ -1,0 +1,6 @@
+
+enhancement:
+  - "Add resources for the Create Tenant job in Prefect Server Helm chart - [#371](https://github.com/PrefectHQ/server/pull/371)"
+
+contributor:
+  - "[Ryan Cheatham](https://github.com/rcheatham-q)"

--- a/helm/prefect-server/templates/jobs/create_tenant.yaml
+++ b/helm/prefect-server/templates/jobs/create_tenant.yaml
@@ -43,6 +43,10 @@ spec:
               value: {{ include "prefect-server.apollo-api-url" . }}
             - name: PREFECT__BACKEND
               value: server
+          {{- with .Values.jobs.createTenant.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
   backoffLimit: {{ .Values.jobs.createTenant.backoffLimit }}
 {{- end }}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -440,5 +440,6 @@ jobs:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    resources: {}
     # backoffLimit configures the number of retries; needed to wait for the server to become available
     backoffLimit: 10


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
Add the ability to specify resources for the Create Tenant job specified in the Prefect Server helm chart.

## Importance
Kubernetes clusters that have resource quotas require resources to be specified for every pod. This means the Create Tenant job cannot be run in such a cluster with the current helm chart.


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
