### PR TITLE
Adds Google Cloud SQL Auth Proxy Support

### DIFF
--- a/changes/pr372.yaml
+++ b/changes/pr372.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - "Adds Google Cloud SQL Auth Proxy Support - [#372](https://github.com/PrefectHQ/server/pull/372)"
+
+contributor:
+  - "[Matt Drago](https://github.com/mattdrago)"

--- a/helm/prefect-server/templates/graphql/deployment.yaml
+++ b/helm/prefect-server/templates/graphql/deployment.yaml
@@ -38,32 +38,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: db-upgrade
-          {{- with .Values.graphql.securityContext -}}          
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          image: "{{ .Values.graphql.image.name }}:{{ .Values.graphql.image.tag |  default .Values.serverVersionTag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.graphql.image.pullPolicy  }}
-          command:
-            - "bash"
-            - "-c"
-            - "/usr/local/bin/prefect-server database upgrade --yes"
-          env:
-            - name: PREFECT_SERVER__DATABASE__CONNECTION_URL
-              value: {{ include "prefect-server.postgres-connstr" . | replace "%40" "@" }}
-            - name: PGPASSWORD
-              valueFrom:
-                {{- include "prefect-server.postgres-secret-ref" . | nindent 16 }}
-            {{- (include "prefect-server.envConfig" .) | nindent 12 }}
-            {{- with .Values.graphql.init.env }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- with .Values.graphql.init.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
       containers:
         - name: graphql
           {{- with .Values.graphql.securityContext -}}          
@@ -75,10 +49,10 @@ spec:
           command: 
             - bash 
             - "-c" 
-            - "python src/prefect_server/services/graphql/server.py"
+            - "${PREFECT_SERVER_DB_CMD} && python src/prefect_server/services/graphql/server.py"
           env:
             - name: PREFECT_SERVER_DB_CMD
-              value: "echo 'DATABASE MIGRATIONS SKIPPED'"
+              value: {{ include "prefect-server.db-cmd" . }}
             - name: PREFECT_SERVER__DATABASE__CONNECTION_URL
               value: {{ include "prefect-server.postgres-connstr" . }}
             - name: PGPASSWORD
@@ -104,6 +78,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- include "prefect-server.gceProxySidecarContainer" . | nindent 8 }}
+      {{- if "prefect-server.gceProxySidecarVolumes" }}
+      volumes:
+        {{- include "prefect-server.gceProxySidecarVolumes" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.graphql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/prefect-server/templates/hasura/deployment.yaml
+++ b/helm/prefect-server/templates/hasura/deployment.yaml
@@ -80,6 +80,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- include "prefect-server.gceProxySidecarContainer" . | nindent 8 }}
+      {{- if "prefect-server.gceProxySidecarVolumes" }}
+      volumes:
+        {{- include "prefect-server.gceProxySidecarVolumes" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hasura.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -86,6 +86,45 @@ postgresql:
   # `internalPostgres` is `true`
   externalHostname: ""
 
+  # upgradeDb defines if the databse should be upgraded when starting
+  # the server
+  upgradeDb: true
+
+  # useGceProxySidecar determines if this chart should deploy the
+  # Cloud SQL Auth Proxy wherever a connection to the Postgres
+  # databse is required.
+  useGceProxySidecar: false
+
+  # gceProxySidecar determines if a gce Proxy sidecar should be
+  # configured to connect to an external Postgresql database hosted
+  # on Google Cloud SQL.
+  gceProxySidecar:
+    # image_version allows for the updating of the version of the
+    # cloud_sql_proxy image to use.
+    image_version: 1.28.0
+
+    cloud_sql_proxy_args:
+      # ip_address_types specifies whether to use PUBLIC or PRIVATE 
+      # ip types.  If connecting from a VPC-native GKE cluster, set
+      # to private to have the proxy connect over a private IP
+      ip_address_types: PUBLIC,PRIVATE
+
+      # instance_connection_name is the connection name of the Cloud SQL
+      # instance that the proxy is to connect to.
+      instance_connection_name: ""
+
+    # service_account holds the details required to configure the proxy
+    # to connect as the provided service account.
+    # See https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#service-account-key-file
+    # for details on how to create/configure the secret
+    service_account:
+      # secret_name is the name of the secret that contains the key file
+      # of the service account that the proxy will use for authentication
+      secret_name: ""
+      filename_in_secret: "service_account.json"
+
+    resources: {}
+
   # useSubChart determines if a this chart should deploy a
   # user-manager postgres database or use an externally managed
   # postgres instance. If `useSubChart` is `true`, the
@@ -195,12 +234,6 @@ graphql:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
-  init:
-    # init.resources configures resources for the initContainer
-    # which upgrades the database
-    env: []
-    resources: {}
 
 # apollo configures the Prefect apollo deployment and service
 # which provides a unified graphql schema for users and the UI


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Adds support to the Helm charts for using the Google Cloud SQL Auth Proxy


## Importance
<!-- Why is this PR important? -->

Under certain conditions, connectivity to a Google Cloud SQL host database can only
be achieved by using the Cloud SQL Auth Proxy.  To utilise the Auth Proxy, a sidecar
container needs to be deployed along with the container that requires a connection
to the database.

Using the Auth Proxy as a sidecar is the recommended approach to connect from 
a Deployment hosted on a Google Kubernetes Engine to a Cloud SQL instance.
See https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#introduction

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] ~~adds new tests (if appropriate)~~
- [x] adds a change file in the `changes/` directory (if appropriate)
