### PR TITLE
fix(helm): update postgres dependency version

### DIFF
--- a/helm/prefect-server/Chart.yaml
+++ b/helm/prefect-server/Chart.yaml
@@ -12,6 +12,6 @@ sources:
   - https://github.com/PrefectHQ/server
 dependencies:
 - name: postgresql
-  version: "~9.3.2"
+  version: "~11.6.16"
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.useSubChart


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Helm would fail error: "Error: can't get a valid version for repositories postgresql. Try changing the version constraint in Chart.yaml". This is because bitnami implemented a retention policy and thereby remove old versions (more info: https://github.com/bitnami/charts/issues/10539). Note, this issue even applies when condition evaluates false.


## Importance
<!-- Why is this PR important? -->

By updating the version to (current) latest chart, helm can now deploy again.



## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
