### PR TITLE
Helm: mount jobTemplateFile from Kubernetes configmap

### DIFF
--- a/changes/379.yaml
+++ b/changes/379.yaml
@@ -1,0 +1,5 @@
+enhancement:
+  - " allow helm users to specify a Kubernetes configmap to be mounted as jobTemplateFile to the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)"
+
+contributor:
+  - "[Michal Luščon](https://github.com/mluscon)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -83,6 +83,12 @@ spec:
           {{- with .Values.agent.env }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+    {{- if .Values.agent.jobTemplateFileConfigMap }}
+        volumeMounts:
+          - mountPath: {{ .Values.agent.jobTemplateFilePath }}
+            name: job-template
+            subPath: {{ base .Values.agent.jobTemplateFilePath }}
+    {{- end }}
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -97,6 +103,12 @@ spec:
       {{- with .Values.agent.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.agent.jobTemplateFileConfigMap }}
+      volumes:
+      - configMap:
+          name: {{ .Values.agent.jobTemplateFileConfigMap }}
+        name: job-template
       {{- end }}
     {{- with .Values.agent.affinity }}
       affinity:

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -357,6 +357,9 @@ agent:
   # reference: https://docs.prefect.io/orchestration/agents/kubernetes.html#custom-job-template
   jobTemplateFilePath: ""
 
+  # mount job template file from Kubernetes configmap. Filename in configmap must match the filename in jobTemplateFilePath.
+  jobTemplateFileConfigMap: ""
+
   # image configures the container image for the agent deployment
   image:
     name: prefecthq/prefect


### PR DESCRIPTION
## Summary
This PR will allow helm users to specify a Kubernetes configmap to be mounted as jobTemplateFile to the agent's container/pod.

## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
