### PR TITLE
helm: create agent's env vars only if input variables are not empty

### DIFF
--- a/changes/380.yaml
+++ b/changes/380.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "helm: create agent's env vars only if input variables are not empty - [#1234](https://github.com/PrefectHQ/server/pull/380)"
+
+contributor:
+  - "[Michal Luščon](https://github.com/mluscon)"

--- a/helm/prefect-server/templates/agent/deployment.yaml
+++ b/helm/prefect-server/templates/agent/deployment.yaml
@@ -60,20 +60,32 @@ spec:
             value: {{ include "prefect-server.apollo-api-url" . }}
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
+        {{- if .Values.agent.job.imagePullSecrets }}
           - name: IMAGE_PULL_SECRETS
             value: {{ .Values.agent.job.imagePullSecrets | join "," | quote }}
+        {{- end }}
           - name: PREFECT__CLOUD__AGENT__LABELS
             value: {{ .Values.agent.prefectLabels | toJson | quote }}
+        {{- if .Values.agent.job.resources.requests.memory }}
           - name: JOB_MEM_REQUEST
             value: {{ .Values.agent.job.resources.requests.memory | quote }}
+        {{- end }}
+        {{- if .Values.agent.job.resources.limits.memory }}
           - name: JOB_MEM_LIMIT
             value: {{ .Values.agent.job.resources.limits.memory | quote }}
+        {{- end }}
+        {{- if .Values.agent.job.resources.requests.cpu }}
           - name: JOB_CPU_REQUEST
             value: {{ .Values.agent.job.resources.requests.cpu | quote }}
+        {{- end }}
+        {{- if .Values.agent.job.resources.limits.cpu }}
           - name: JOB_CPU_LIMIT
             value: {{ .Values.agent.job.resources.limits.cpu | quote }}
+        {{- end }}
+        {{- if .Values.agent.job.imagePullPolicy }}
           - name: IMAGE_PULL_POLICY
             value: {{ .Values.agent.job.imagePullPolicy | quote }}
+        {{- end }}
           - name: SERVICE_ACCOUNT_NAME
             value: {{ include "prefect-server.serviceAccountName" . }}
           - name: PREFECT__BACKEND


### PR DESCRIPTION
## Summary
helm: create agent's env vars only if input variables are not empty

## Importance
Without this PR, helm with default values.yaml (e.g.  `agent: job : imagePullSecrets: []`) creates empty environment variable IMAGE_PULL_SECRETS in agent's pod that takes precedes over imagePullSecrets from serviceaccount or job template file.




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
