### PR TITLE
Release 2022.09.07

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2022.09.07 <Badge text="beta" type="success" />
+
+Released on September 7, 2022.
+
+### Enhancements
+
+-  allow helm users to specify a Kubernetes configmap to be mounted as jobTemplateFile to the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)
+- Improve init container template for graphql - [#370](https://github.com/PrefectHQ/server/pull/370)
+
+### Fixes
+
+- helm: create agent's env vars only if input variables are not empty - [#1234](https://github.com/PrefectHQ/server/pull/380)
+
+### Contributors
+
+- [André Nogueira](https://github.com/aanogueira)
+- [Michal Luščon](https://github.com/mluscon)
+
 ## 2022.04.14 <Badge text="beta" type="success" />
 
 Released on April 14, 2022.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,20 +3,22 @@
 ## 2022.09.07 <Badge text="beta" type="success" />
 
 Released on September 7, 2022.
+### Helm
 
-### Enhancements
+WARNING: This release of the Helm chart includes a breaking change with the upgrade from PostgreSQL 9 to 11. This is required because bitnami no longer hosts the old version of Postgres. If updating from a prior Helm chart release, please take care to back up your database.
 
--  allow helm users to specify a Kubernetes configmap to be mounted as jobTemplateFile to the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)
+- Allow users to specify a Kubernetes config map to be mounted as `jobTemplateFile` in the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)
 - Improve init container template for graphql - [#370](https://github.com/PrefectHQ/server/pull/370)
-
-### Fixes
-
-- helm: create agent's env vars only if input variables are not empty - [#1234](https://github.com/PrefectHQ/server/pull/380)
+- Create agent's env vars only if input variables are not empty - [#380](https://github.com/PrefectHQ/server/pull/380)
+- Update PostgreSQL from ~9 to ~11 — [#375](https://github.com/PrefectHQ/server/pull/375)
+- Allow specification of resources for the tenant creation job — [#371](https://github.com/PrefectHQ/server/pull/371)
 
 ### Contributors
 
+- [Amit Zafran](https://github.com/amitza)
 - [André Nogueira](https://github.com/aanogueira)
 - [Michal Luščon](https://github.com/mluscon)
+- [rcheatham-q](https://github.com/rcheatham-q)
 
 ## 2022.04.14 <Badge text="beta" type="success" />
 

--- a/changes/379.yaml
+++ b/changes/379.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - " allow helm users to specify a Kubernetes configmap to be mounted as jobTemplateFile to the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)"
-
-contributor:
-  - "[Michal Luščon](https://github.com/mluscon)"

--- a/changes/380.yaml
+++ b/changes/380.yaml
@@ -1,5 +1,0 @@
-fix:
-  - "helm: create agent's env vars only if input variables are not empty - [#1234](https://github.com/PrefectHQ/server/pull/380)"
-
-contributor:
-  - "[Michal Luščon](https://github.com/mluscon)"

--- a/changes/pr370.yaml
+++ b/changes/pr370.yaml
@@ -1,5 +1,0 @@
-enhancement:
-  - "Improve init container template for graphql - [#370](https://github.com/PrefectHQ/server/pull/370)"
-
-contributor:
-  - "[André Nogueira](https://github.com/aanogueira)"


### PR DESCRIPTION
## Changes

### Helm

WARNING: This release of the Helm chart includes a breaking change with the upgrade from PostgreSQL 9 to 11. This is required because bitnami no longer hosts the old version of Postgres. If updating from a prior Helm chart release, please take care to back up your database.

- Allow users to specify a Kubernetes config map to be mounted as `jobTemplateFile` in the agent's container - [#379](https://github.com/PrefectHQ/server/pull/379)
- Improve init container template for graphql - [#370](https://github.com/PrefectHQ/server/pull/370)
- Create agent's env vars only if input variables are not empty - [#380](https://github.com/PrefectHQ/server/pull/380)
- Update PostgreSQL from ~9 to ~11 — [#375](https://github.com/PrefectHQ/server/pull/375)
- Allow specification of resources for the tenant creation job — [#371](https://github.com/PrefectHQ/server/pull/371)

### Contributors

- [Amit Zafran](https://github.com/amitza)
- [André Nogueira](https://github.com/aanogueira)
- [Michal Luščon](https://github.com/mluscon)
- [rcheatham-q](https://github.com/rcheatham-q)