### PR TITLE
Backport: Install prefect from 1.x branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ aliases:
     run:
       name: Set environment variables
       command: |
-        # set prefect tag -- currently pinning to master
-        echo 'export PREFECT_VERSION=master' >> $BASH_ENV
+        # set prefect tag -- currently pinning to 1.x branch
+        echo 'export PREFECT_VERSION=1.x' >> $BASH_ENV
 
   - &install_prefect_server
     run:
       name: Install Prefect Server
       command: |
-        # install prefect master
+        # install prefect from 1.x branch
         pip install --progress-bar off "git+https://github.com/prefecthq/prefect.git@${PREFECT_VERSION}"
         # install prefect server
         pip install --progress-bar off -e ".[dev]"


### PR DESCRIPTION
Install Prefect 1 from the 1.x branch, instead of master.

<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
