### PR TITLE
Account for nesting of postgresql.existingSecret

### DIFF
--- a/helm/prefect-server/templates/_helpers.tpl
+++ b/helm/prefect-server/templates/_helpers.tpl
@@ -129,8 +129,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     an existing secret is not set.
 */}}
 {{- define "prefect-server.postgres-secret-name" -}}
-{{- if .Values.postgresql.existingSecret -}}
-  {{- .Values.postgresql.existingSecret -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+  {{- .Values.postgresql.auth.existingSecret -}}
 {{- else -}}
   {{- printf "%s-%s" .Release.Name "postgresql" -}}
 {{- end -}}


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

Account for nesting of `postgresql.existingSecret` into `postgresql.auth.existingSecret`


## Importance
<!-- Why is this PR important? -->

nesting was increased in https://github.com/PrefectHQ/server/commit/fc97f3209c8e453f21f56164eb4ba830df272e03


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
