### PR TITLE
docs: fix postgresql-password -> postgres-password

### DIFF
--- a/changes/pr407.yaml
+++ b/changes/pr407.yaml
@@ -1,0 +1,5 @@
+fix:
+  - "docs: fix postgresql-password -> postgres-password - [#407](https://github.com/PrefectHQ/server/pull/407)"
+
+contributor:
+  - "[Joël Luijmes](https://github.com/joelluijmes)"

--- a/helm/prefect-server/README.md
+++ b/helm/prefect-server/README.md
@@ -197,10 +197,10 @@ We strongly recommend that you do not deploy a production database using this ch
 The provided database will **not** persist your data by default.
 When connecting to an external database, PostgreSQL 11+ is recommended.
 
-In order to use an external database with this Helm chart, you need to create a Kubernetes secret that will contain the database password. This secret must be a key-value pair containing the key `postgresql-password`. You need to create this secret yourself, then reference the secret name using `existingSecret`. The name of the Kubernetes secret is arbitrary, e.g.: 
+In order to use an external database with this Helm chart, you need to create a Kubernetes secret that will contain the database password. This secret must be a key-value pair containing the key `postgres-password`. You need to create this secret yourself, then reference the secret name using `existingSecret`. The name of the Kubernetes secret is arbitrary, e.g.: 
 
 ```shell
-kubectl create secret generic prefect-postgresql-pwd --from-literal='postgresql-password=YOUR_POSTGRES_PWD'
+kubectl create secret generic prefect-postgresql-pwd --from-literal='postgres-password=YOUR_POSTGRES_PWD'
 ```
 
 Then, add the flag `--set postgresql.existingSecret=prefect-postgresql-pwd` to the helm install command to use this secret to connect to your database.

--- a/helm/prefect-server/values.yaml
+++ b/helm/prefect-server/values.yaml
@@ -59,7 +59,7 @@ postgresql:
     # postgresql.auth.password sets the password to be used if
     # `existingSecret` is not set. This is the password for
     # `postgresqlUsername` and will be set within the secret at
-    # the key `postgresql-password`. This argument is only relevant
+    # the key `postgres-password`. This argument is only relevant
     # when using the Postgres database included in the chart.
     # For an external postgres connection, you must create
     # and use `existingSecret` instead of `postgresqlPassword`.
@@ -73,7 +73,7 @@ postgresql:
     # enabled, the secret will be generated. If using an external
     # postgres service, this value should be set to the name of
     # an existing Kubernetes secret. This secret must contain
-    # a key-value pair where the key is `postgresql-password `
+    # a key-value pair where the key is `postgres-password `
     # and the value is your password. For more information,
     # see the "Database" section of the README.
     existingSecret: null


### PR DESCRIPTION
<!-- Thanks for contributing to Prefect Server! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->

The documentation refers to different secret than is actually used in the Helm chart. [Although, I actually think the secret is renamed at some point 🤷 ].

## Importance
<!-- Why is this PR important? -->

If the wrong secret is configured, the pods will never come online:
```
CreateContainerConfigError: couldn't find key postgres-password in Secret prefect/prefect-postgresql 
```


## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [x] adds new tests (if appropriate)
- [x] adds a change file in the `changes/` directory (if appropriate)
